### PR TITLE
A slightly more configurable footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -77,7 +77,7 @@ function Footer(props) {
   return (
     <footer className='sgds-footer'>
       <div className="top-section">
-        <div className="sgds-container is-fluid">
+        <div className={`sgds-container ${props.isFluid ? "is-fluid" : ""}`}>
           <div className="row">
             <div className="col">
               <h5 className="has-text-white"><b>{props.title}</b></h5>
@@ -97,7 +97,7 @@ function Footer(props) {
       </div>
 
       <div className="bottom-section">
-        <div className="sgds-container is-fluid">
+        <div className={`sgds-container ${props.isFluid ? "is-fluid" : ""}`}>
           <div className="row is-multiline">
             <div className="col is-12">
               <ul>
@@ -120,7 +120,8 @@ Footer.propTypes = {
     termsOfUse: PropTypes.string,
     contact: PropTypes.string,
     feedback: PropTypes.string
-  })
+  }),
+  isFluid: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,67 +1,70 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 // TODO : Improve error handling of inputs into components
-class Footer extends Component{
-
-  getDateYear(date){
+function Footer(props) {
+  const getDateYear = (date) => {
     let dateRegex = /^([0-9]|[0-2][0-9]|[3][0-1]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4})$/i
     let matches = dateRegex.exec(date)
-    if(matches){
-      return [matches[0],matches[3]]
-    }else{
+    if (matches) {
+      return [matches[0], matches[3]]
+    } else {
       throw new Error('Invalid date format for Footer: Only dd MMM yyyy date formats accepted')
     }
   }
+
   // TODO : Refine code in renderBottomButtons() and renderBottomRightTopSectionLinks()
-  renderBottomButtons(){
+  const renderBottomButtons = () => {
     let links = [];
     links.push(
-    <li key="vuln">
-      <a href="https://tech.gov.sg/report_vulnerability" target="_blank" rel="noopener noreferrer">Report Vulnerability</a>
-    </li>
+      <li key="vuln">
+        <a href="https://tech.gov.sg/report_vulnerability" target="_blank" rel="noopener noreferrer">Report
+          Vulnerability</a>
+      </li>
     )
-    if(!this.props.links){
-      return 
-    }
-    if(this.props.links.privacy){
-      links.push(<li key="privacy"><a href={this.props.links.privacy}>Privacy</a></li>);
-    }
-    if(this.props.links.termsOfUse){
-      links.push(<li key="termsOfUse"><a href={this.props.links.termsOfUse}>Terms of Use</a></li>)
-    }
-    return links
-  }
-  renderBottomRightTopSectionLinks(){
-    let links = [];
-    if(!this.props.links){
+    if (!props.links) {
       return
     }
-    if(this.props.links.contact){
-      links.push((      
-      <li key="contact" className="is-inline-block-desktop-only">
-        <p>
-          <a href={this.props.links.contact} target="_blank" rel="noopener noreferrer">Contact</a>
-        </p>
-      </li>
+    if (props.links.privacy) {
+      links.push(<li key="privacy"><a href={props.links.privacy}>Privacy</a></li>);
+    }
+    if (props.links.termsOfUse) {
+      links.push(<li key="termsOfUse"><a href={props.links.termsOfUse}>Terms of Use</a></li>)
+    }
+    return links
+  }
+
+  const renderBottomRightTopSectionLinks = () => {
+    let links = [];
+    if (!props.links) {
+      return
+    }
+    if (props.links.contact) {
+      links.push((
+        <li key="contact" className="is-inline-block-desktop-only">
+          <p>
+            <a href={props.links.contact} target="_blank" rel="noopener noreferrer">Contact</a>
+          </p>
+        </li>
       ))
     }
-    if(this.props.links.feedback){
+    if (props.links.feedback) {
       links.push((
-      <li key="feedback" className="is-inline-block-desktop-only">
-        <p>
-          <a href={this.props.links.feedback} target="_blank" rel="noopener noreferrer">Feedback</a>
-        </p>
-      </li>
+        <li key="feedback" className="is-inline-block-desktop-only">
+          <p>
+            <a href={props.links.feedback} target="_blank" rel="noopener noreferrer">Feedback</a>
+          </p>
+        </li>
       ))
     }
     return links
   }
-  renderBottomFooterText(){
-    if(!this.props.date){
-      return 
+
+  const renderBottomFooterText = () => {
+    if (!props.date) {
+      return
     }
-    let [date,year] = this.getDateYear(this.props.date)
-    return(
+    let [date, year] = getDateYear(props.date)
+    return (
       <div className="col is-12 has-text-right-desktop has-text-right-tablet has-text-left-mobile">
         <p className="is-hidden-touch"> © {year} Government of Singapore. Last Updated {date}</p>
         <p className="is-hidden-desktop">© {year} Government of Singapore</p>
@@ -69,44 +72,43 @@ class Footer extends Component{
       </div>
     )
   }
-  render(){
-    return(
-      <footer className='sgds-footer'>
-          <div className="top-section">
-              <div className="sgds-container is-fluid">
-                  <div className="row">
-                      <div className="col">
-                        <h5 className="has-text-white"><b>{this.props.title}</b></h5>
-                      </div>
-                  </div>
-                  <div className="row">
-                    {this.props.children}
-                  </div>
-                  <div className="row">
-                      <div className="col is-right-desktop-only">
-                          <ul>
-                             {this.renderBottomRightTopSectionLinks()}
-                          </ul>
-                      </div>
-                  </div>
-              </div>
-          </div>
 
-          <div className="bottom-section">
-              <div className="sgds-container is-fluid">
-                  <div className="row is-multiline">
-                      <div className="col is-12">
-                          <ul>
-                             {this.renderBottomButtons()}
-                          </ul>
-                      </div>
-                         {this.renderBottomFooterText()}
-                  </div>
-              </div>
+  return (
+    <footer className='sgds-footer'>
+      <div className="top-section">
+        <div className="sgds-container is-fluid">
+          <div className="row">
+            <div className="col">
+              <h5 className="has-text-white"><b>{props.title}</b></h5>
+            </div>
           </div>
-      </footer>
-    );
-  }
+          <div className="row">
+            {props.children}
+          </div>
+          <div className="row">
+            <div className="col is-right-desktop-only">
+              <ul>
+                {renderBottomRightTopSectionLinks()}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="bottom-section">
+        <div className="sgds-container is-fluid">
+          <div className="row is-multiline">
+            <div className="col is-12">
+              <ul>
+                {renderBottomButtons()}
+              </ul>
+            </div>
+            {renderBottomFooterText()}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
 }
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from "prop-types";
 
 // TODO : Improve error handling of inputs into components
 function Footer(props) {
@@ -109,6 +110,17 @@ function Footer(props) {
       </div>
     </footer>
   );
-}
+};
+
+Footer.propTypes = {
+  title: PropTypes.string,
+  date: PropTypes.string,
+  links: PropTypes.objectOf({
+    privacy: PropTypes.string,
+    termsOfUse: PropTypes.string,
+    contact: PropTypes.string,
+    feedback: PropTypes.string
+  })
+};
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -115,13 +115,13 @@ function Footer(props) {
 Footer.propTypes = {
   title: PropTypes.string,
   date: PropTypes.string,
-  links: PropTypes.objectOf({
+  links: PropTypes.shape({
     privacy: PropTypes.string,
     termsOfUse: PropTypes.string,
     contact: PropTypes.string,
     feedback: PropTypes.string
   }),
-  isFluid: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  isFluid: PropTypes.bool
 };
 
 export default Footer;

--- a/stories/components/Footer.stories.js
+++ b/stories/components/Footer.stories.js
@@ -16,6 +16,12 @@ import { Footer } from 'sgds-govtech-react'
 
 `;
 const code2 = `
+import { Footer } from 'sgds-govtech-react' 
+
+<Footer title="Singapore Design Systems" date="15 Aug 2019" isFluid/>
+
+`;
+const code3 = `
 const links = {
   privacy: " ",
   termsOfUse: " ",
@@ -25,7 +31,7 @@ const links = {
 
 <Footer title="Singapore Design Systems" date="15 Aug 2019" links={links}/>
 `;
-const code3 = `
+const code4 = `
 const links = {
   privacy: " ",
   termsOfUse: " ",
@@ -69,6 +75,12 @@ const FooterStories = props => {
 
         <Divider />
 
+        <h4>Fluid Footer</h4>
+        <Footer title="Singapore Design Systems" date="15 Aug 2019" isFluid></Footer>
+        <SyntaxHighlighter>{formatCode(code2)}</SyntaxHighlighter>
+
+        <Divider />
+
         <h4>Footer with necessary links</h4>
 
         <Footer
@@ -76,7 +88,7 @@ const FooterStories = props => {
           date="15 Aug 2019"
           links={links}
         ></Footer>
-        <SyntaxHighlighter>{formatCode(code2)}</SyntaxHighlighter>
+        <SyntaxHighlighter>{formatCode(code3)}</SyntaxHighlighter>
 
         <Divider />
 
@@ -109,7 +121,7 @@ const FooterStories = props => {
             </p>
           </div>
         </Footer>
-        <SyntaxHighlighter>{formatCode(code3)}</SyntaxHighlighter>
+        <SyntaxHighlighter>{formatCode(code4)}</SyntaxHighlighter>
       </section>
     </Page>
   );


### PR DESCRIPTION
I have added configuration for `is-fluid` classname to the Footer sections via `isFluid` prop (similar to other components like `Container` and `MainNav`).

Included as well are some quality of life updates:
- Converted `Footer` to a React functional component
- Added PropTypes for existing props
- Added example Fluid Footer to the `Footer` stories in Storybook