### PR TITLE
Button passes on unhandled props to underlying component

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import getUnhandledProps from "../lib/getUnhandledProps";
 
 class Button extends Component {
   constructor(props) {
@@ -111,6 +112,8 @@ class Button extends Component {
   };
 
   render() {
+    const rest = getUnhandledProps(Button.propTypes, this.props);
+
     return (
       <button
         className={this.getClassName()}
@@ -129,6 +132,7 @@ class Button extends Component {
         onClick={this.onClick}
         onFocus={() => this.setState({ focused: true })}
         onBlur={() => this.setState({ focused: false })}
+        {...rest}
       >
         {this.props.children}
       </button>

--- a/src/lib/getUnhandledProps.js
+++ b/src/lib/getUnhandledProps.js
@@ -1,0 +1,8 @@
+const getUnhandledProps = (propTypes, props) => (
+  Object.keys(props).reduce((acc, prop) => {
+    if (!propTypes.hasOwnProperty(prop)) acc[prop] = props[prop];
+    return acc;
+  }, {})
+)
+
+export default getUnhandledProps;

--- a/stories/components/Buttons.stories.js
+++ b/stories/components/Buttons.stories.js
@@ -68,6 +68,12 @@ const buttonCode3 = `
 <Button colorType="danger">Danger</Button>
 </>
 `;
+const buttonCode4 = `
+<>
+<Button aria-label="Close">Put &quot;X&quot; icon here; screenreader reads &quot;Close&quot;</Button>
+<Button data-example="value">I have a data- attribute on me!</Button>
+</>
+`;
 const ButtonStories = props => {
   return (
     <Page>
@@ -178,6 +184,15 @@ const ButtonStories = props => {
           <Button colorType="danger">Danger</Button>
         </RowButtonContainer>
         <SyntaxHighlighter>{formatCode(buttonCode3)}</SyntaxHighlighter>
+
+        <Divider />
+        <h4>Additional attributes</h4>
+        <p>You can provide your own attributes as well.</p>
+        <RowButtonContainer>
+          <Button aria-label="Close">Put &quot;X&quot; icon here; screenreader reads &quot;Close&quot;</Button>
+          <Button data-example="value">I have a data- attribute on me!</Button>
+        </RowButtonContainer>
+        <SyntaxHighlighter>{formatCode(buttonCode4)}</SyntaxHighlighter>
       </section>
     </Page>
   );


### PR DESCRIPTION
Hi there, wondering what you all think about forwarding props that a component doesn't use/handle to the underlying element. For example, the `<Button>` component currently takes in props like `buttonSize` etc, but doesn't pass on other props given to it. It would be useful if it could pass on the props that it doesn't use/handle. Some attributes that might be useful to pass through that I can think of are the `aria-` attributes (for accessibility), and the `data-` attributes (application-specific). This is something usually done by component libraries like Semantic UI, React Bootstrap, etc.

Wanted to see if there is interest from the team so I just did `<Button>` instead of doing for every single component. Look forward to hearing from you all.