### PR TITLE
Implement a11y recommendations

### DIFF
--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -89,6 +89,7 @@ export const DropdownToggle: DropdownToggleComponent = React.forwardRef(
         variant="outline-secondary"
         {...toggleProps}
         {...props}
+        aria-haspopup="menu"
       />
     );
   },

--- a/src/Nav/NavLink.tsx
+++ b/src/Nav/NavLink.tsx
@@ -88,6 +88,7 @@ export const NavLink: BsPrefixRefForwardingComponent<'a', NavLinkProps> =
             props.disabled && 'disabled',
             meta.isActive && 'active'
           )}
+          aria-current={meta.isActive ? "page" : "false"}
         />
       );
     }

--- a/src/Nav/NavbarToggle.tsx
+++ b/src/Nav/NavbarToggle.tsx
@@ -76,6 +76,7 @@ export const NavbarToggle: BsPrefixRefForwardingComponent<
         onClick={handleClick}
         aria-label={label}
         className={classNames(className, bsPrefix, !expanded && 'collapsed')}
+        aria-expanded={expanded}
       >
         {children || <span className={`${bsPrefix}-icon`} />}
       </Component>

--- a/src/SideNav/SideNavButton.tsx
+++ b/src/SideNav/SideNavButton.tsx
@@ -108,6 +108,7 @@ export const SideNavButton: BsPrefixRefForwardingComponent<
         onClick={sideNavOnClick}
         {...props}
         aria-expanded={eventKey === activeEventKey}
+        aria-haspopup="menu"
         className={classNames(
           className,
           setCollapseCSS(activeEventKey, eventKey)

--- a/src/SideNav/SideNavLink.tsx
+++ b/src/SideNav/SideNavLink.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { BsPrefixRefForwardingComponent } from '../utils/helpers';
 import SideNavContext from './SideNavContext';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 export interface SideNavLinkProps extends Omit<NavLinkProps, 'eventKey'> {
   /** A unique key for SideNavLink */
@@ -22,7 +21,7 @@ export const SideNavLink: BsPrefixRefForwardingComponent<'a', SideNavLinkProps> 
           {...props}
           ref={ref}
           eventKey={eventKey}
-          className={classNames( activeLinkKey === eventKey && 'active' )}
+          active={activeLinkKey === eventKey}
         />
       );
     }

--- a/tests/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/tests/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`<Tabs> Should render TabPane with role="tab" 1`] = `
     >
       <button
         aria-controls="test-tabpane-1"
+        aria-current="page"
         aria-selected="true"
         class="nav-link active"
         data-rr-ui-event-key="1"


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

### Checklist:

**Dropdown button:**
- [x] Add aria-haspopup="true" to each dropdown button to indicate to screen reader that there is a sub menu in this button.

**Navigation (navbar & sidenav):**
- [x] Add aria-haspopup="true" to each dropdown and megamenu button.
- [x] Add aria-current="page" to the active link on the nav to indicate to screen reader that this is the current page.
- [x] For mobile menu hamburger button, add aria-expanded attribute to indicate if the menu has been revealed.

**Pagination:**
- [ ] Pagination is also considered a navigation so can consider using <nav>. 
If changing to <nav>, add aria-label attribute to the <nav> to differentiate it from the main nav.

- [ ] Add this text below to explain why aria-label is needed if there are multiple <nav> in a page.
“The aria-label attribute has been added to the <nav> element. This is because the main website navigation also uses the <nav> element. Where there are multiple <nav> elements on a single page, all must be given a unique accessible name via aria-label.”

**Stepper:**
- [ ] Going back to step 1 is only clickable and not keyboard accessible (can consider using tabindex).
- [ ] Add aria-current="step" to the current step div to inform screen reader that this is their current step (currently, the only way to tell is by looking at the visual difference).

**Form:**
- [ ] For invalid feedback, error message is compulsory and should link to the input via aria-errormessage and aria-invalid="true".
- [ ] For valid feedback, success message can still be optional but if used, need to link to input via aria-describedby
- [ ] First “Email address” example is not associated using aria-describedby.

**QuantityToggle:**
- [ ] Change the aria-label for the minus and plus buttons using proper english words.
- [ ] (Bonus) Add an announcer for screen reader users to know the count after every increment or decrement.
`<div id="announcer" role="region" aria-live="assertive" class="visually-hidden">{number}</div>`

**Tooltip:**
- [ ] Tooltip is not announced to screen reader users (Can explore using aria-describedby to associate the tooltip content with the main element.)
Example here: https://dequeuniversity.com/library/aria/tooltip

**Datepicker:**
- [ ] Current datepicker is not keyboard and screen reader accessible.
Example here: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/