### PR TITLE
Implement a11y for Dropdown button

### DIFF
--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -89,6 +89,7 @@ export const DropdownToggle: DropdownToggleComponent = React.forwardRef(
         variant="outline-secondary"
         {...toggleProps}
         {...props}
+        aria-haspopup="menu"
       />
     );
   },


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

- [x] Add `aria-haspopup="true"` to each dropdown button to indicate to screen reader that there is a sub menu in this button.