### PR TITLE
Implement a11y for Navigation

### DIFF
--- a/src/Nav/NavLink.tsx
+++ b/src/Nav/NavLink.tsx
@@ -88,6 +88,7 @@ export const NavLink: BsPrefixRefForwardingComponent<'a', NavLinkProps> =
             props.disabled && 'disabled',
             meta.isActive && 'active'
           )}
+          aria-current={meta.isActive ? "page" : "false"}
         />
       );
     }

--- a/src/Nav/NavbarToggle.tsx
+++ b/src/Nav/NavbarToggle.tsx
@@ -76,6 +76,7 @@ export const NavbarToggle: BsPrefixRefForwardingComponent<
         onClick={handleClick}
         aria-label={label}
         className={classNames(className, bsPrefix, !expanded && 'collapsed')}
+        aria-expanded={expanded}
       >
         {children || <span className={`${bsPrefix}-icon`} />}
       </Component>

--- a/src/SideNav/SideNavButton.tsx
+++ b/src/SideNav/SideNavButton.tsx
@@ -108,6 +108,7 @@ export const SideNavButton: BsPrefixRefForwardingComponent<
         onClick={sideNavOnClick}
         {...props}
         aria-expanded={eventKey === activeEventKey}
+        aria-haspopup="menu"
         className={classNames(
           className,
           setCollapseCSS(activeEventKey, eventKey)

--- a/src/SideNav/SideNavLink.tsx
+++ b/src/SideNav/SideNavLink.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { BsPrefixRefForwardingComponent } from '../utils/helpers';
 import SideNavContext from './SideNavContext';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 export interface SideNavLinkProps extends Omit<NavLinkProps, 'eventKey'> {
   /** A unique key for SideNavLink */
@@ -22,7 +21,7 @@ export const SideNavLink: BsPrefixRefForwardingComponent<'a', SideNavLinkProps> 
           {...props}
           ref={ref}
           eventKey={eventKey}
-          className={classNames( activeLinkKey === eventKey && 'active' )}
+          active={activeLinkKey === eventKey}
         />
       );
     }

--- a/tests/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/tests/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`<Tabs> Should render TabPane with role="tab" 1`] = `
     >
       <button
         aria-controls="test-tabpane-1"
+        aria-current="page"
         aria-selected="true"
         class="nav-link active"
         data-rr-ui-event-key="1"


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

**Navigation (navbar & sidenav):**
- [x] Add `aria-haspopup="true"` to each dropdown and megamenu button.
- [x] Add `aria-current="page"` to the active link on the nav to indicate to screen reader that this is the current page.
- [x] For mobile menu hamburger button, add aria-expanded attribute to indicate if the menu has been revealed.
