### PR TITLE
Implement a11y for Pagination

### DIFF
--- a/src/Pagination/PaginationBase.tsx
+++ b/src/Pagination/PaginationBase.tsx
@@ -10,7 +10,7 @@ type PaginationBaseSize = 'sm' | 'md' | 'lg';
 
 export interface PaginationBaseProps
   extends BsPrefixProps,
-    React.HTMLAttributes<HTMLUListElement> {
+  React.HTMLAttributes<HTMLUListElement> {
   size?: 'sm' | 'md' | 'lg';
 }
 
@@ -40,16 +40,17 @@ const PaginationBase = React.forwardRef<HTMLUListElement, PaginationBaseProps>(
   ({ bsPrefix, className, size, ...props }, ref) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'pagination');
     return (
-      <SGDSWrapper
-        as="ul"
-        ref={ref}
-        {...props}
-        className={classNames(
-          className,
-          decoratedBsPrefix,
-          size && `${decoratedBsPrefix}-${size}`
-        )}
-      />
+      <SGDSWrapper as='nav' aria-label='Page Navigation'>
+        <ul
+          ref={ref}
+          {...props}
+          className={classNames(
+            className,
+            decoratedBsPrefix,
+            size && `${decoratedBsPrefix}-${size}`
+          )}>
+        </ul>
+      </SGDSWrapper>
     );
   }
 );

--- a/stories/Pagination/Pagination.stories.mdx
+++ b/stories/Pagination/Pagination.stories.mdx
@@ -603,3 +603,7 @@ it will decrement/increment to the end of the pages respectively.
     {PaginationTpl.bind({})}
   </Story>
 </Canvas>
+
+## Accessibility
+
+The aria-label attribute has been added to the `<nav>` element of Pagination. This is because sgds's Nav and SideNav also use the `<nav>` element. Where there are multiple `<nav>` elements on a single page, all must be given a unique accessible name via `aria-label`.

--- a/tests/Paginations/PaginationBase.test.js
+++ b/tests/Paginations/PaginationBase.test.js
@@ -2,14 +2,20 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import  PaginationBase  from '../../src/Pagination/PaginationBase';
 
+//React-testing-library 
+import { render }  from '@testing-library/react';
+
 describe('<PaginationBase>', () => {
   it('should have class', () => {
-    const wrapper = shallow(<PaginationBase/>);
-    expect(wrapper.hasClass('pagination')).toEqual(true);
+    const { container } = render(<PaginationBase/>);
+    const $paginationUl = container.querySelector('ul');
+    expect($paginationUl.classList).toContain('pagination');
   });
 
   it('should render correctly when size is set', () => {
-     const wrapper = shallow(<PaginationBase size='sm'/>);
-     expect(wrapper.is('.pagination.pagination-sm')).toEqual(true);
+     const { container } = render(<PaginationBase size='sm'/>);
+     const $paginationUl = container.querySelector('ul');
+     expect($paginationUl.classList).toContain('pagination');
+     expect($paginationUl.classList).toContain('pagination-sm');
   });
 });

--- a/tests/Paginations/Paginations.test.js
+++ b/tests/Paginations/Paginations.test.js
@@ -13,7 +13,6 @@ describe('<Pagination>', () => {
     expect($pagination).toBeDefined()
     expect($pagination.classList).toContain('pagination')
     expect($pagination.classList).toContain('pagination-sm')
-    expect($pagination.classList).toContain('sgds')
 
     //test that icons present 
     //two icons 


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

- [x] Pagination is also considered a navigation so can consider using `<nav>`. 
If changing to <nav>, add aria-label attribute to the `<nav>` to differentiate it from the main nav.
- [x] Add this text below to explain why `aria-label` is needed if there are multiple `<nav>` in a page.
“The aria-label attribute has been added to the `<nav>` element. This is because the main website navigation also uses the `<nav>` element. Where there are multiple `<nav>` elements on a single page, all must be given a unique accessible name via `aria-label`.”