### PR TITLE
Implement a11y for Stepper

### DIFF
--- a/src/Stepper/Stepper.tsx
+++ b/src/Stepper/Stepper.tsx
@@ -52,6 +52,7 @@ const Stepper: React.FC<StepperProps> = ({ methods }) => {
           className={`stepper-item ${getClass(stepMetadata)}`}
           onClick={back(stepMetadata)}
           key={stepMetadata.step}
+          tabIndex={0}
         >
           <div className="stepper-marker">{stepMetadata.step}</div>
           <div className="stepper-detail">

--- a/src/Stepper/Stepper.tsx
+++ b/src/Stepper/Stepper.tsx
@@ -53,6 +53,7 @@ const Stepper: React.FC<StepperProps> = ({ methods }) => {
           onClick={back(stepMetadata)}
           key={stepMetadata.step}
           tabIndex={0}
+          aria-current={stepMetadata.step === state.currentStep ? "step" : "false"}
         >
           <div className="stepper-marker">{stepMetadata.step}</div>
           <div className="stepper-detail">

--- a/tests/Stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/tests/Stepper/__snapshots__/Stepper.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Stepper Stepper interactions with onClick methods 1`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -27,6 +28,7 @@ exports[`Stepper Stepper interactions with onClick methods 1`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -46,6 +48,7 @@ exports[`Stepper Stepper interactions with onClick methods 1`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -101,6 +104,7 @@ exports[`Stepper Stepper interactions with onClick methods 2`] = `
     <div
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -120,6 +124,7 @@ exports[`Stepper Stepper interactions with onClick methods 2`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -139,6 +144,7 @@ exports[`Stepper Stepper interactions with onClick methods 2`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -200,6 +206,7 @@ exports[`Stepper Stepper interactions with onClick methods 3`] = `
     <div
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -219,6 +226,7 @@ exports[`Stepper Stepper interactions with onClick methods 3`] = `
     <div
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -238,6 +246,7 @@ exports[`Stepper Stepper interactions with onClick methods 3`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -304,6 +313,7 @@ exports[`Stepper Stepper interactions with onClick methods 4`] = `
     <div
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -323,6 +333,7 @@ exports[`Stepper Stepper interactions with onClick methods 4`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -342,6 +353,7 @@ exports[`Stepper Stepper interactions with onClick methods 4`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -403,6 +415,7 @@ exports[`Stepper Stepper interactions with onClick methods 5`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -422,6 +435,7 @@ exports[`Stepper Stepper interactions with onClick methods 5`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -441,6 +455,7 @@ exports[`Stepper Stepper interactions with onClick methods 5`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -496,6 +511,7 @@ exports[`Stepper Stepper interactions with onClick methods 6`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -515,6 +531,7 @@ exports[`Stepper Stepper interactions with onClick methods 6`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -534,6 +551,7 @@ exports[`Stepper Stepper interactions with onClick methods 6`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -589,6 +607,7 @@ exports[`Stepper Stepper interactions with onClick methods 7`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -608,6 +627,7 @@ exports[`Stepper Stepper interactions with onClick methods 7`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -627,6 +647,7 @@ exports[`Stepper Stepper interactions with onClick methods 7`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -682,6 +703,7 @@ exports[`Stepper Stepper interactions with onClick methods 8`] = `
     <div
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -701,6 +723,7 @@ exports[`Stepper Stepper interactions with onClick methods 8`] = `
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -720,6 +743,7 @@ exports[`Stepper Stepper interactions with onClick methods 8`] = `
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -781,6 +805,7 @@ exports[`Stepper default html structure, with minimal required stepMethods 1`] =
     <div
       class="stepper-item is-active"
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -800,6 +825,7 @@ exports[`Stepper default html structure, with minimal required stepMethods 1`] =
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"
@@ -819,6 +845,7 @@ exports[`Stepper default html structure, with minimal required stepMethods 1`] =
     <div
       class="stepper-item "
       data-testid="sgds-step"
+      tabindex="0"
     >
       <div
         class="stepper-marker"

--- a/tests/Stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/tests/Stepper/__snapshots__/Stepper.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Stepper Stepper interactions with onClick methods 1`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -26,6 +27,7 @@ exports[`Stepper Stepper interactions with onClick methods 1`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -46,6 +48,7 @@ exports[`Stepper Stepper interactions with onClick methods 1`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -102,6 +105,7 @@ exports[`Stepper Stepper interactions with onClick methods 2`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="false"
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
       tabindex="0"
@@ -122,6 +126,7 @@ exports[`Stepper Stepper interactions with onClick methods 2`] = `
       </div>
     </div>
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -142,6 +147,7 @@ exports[`Stepper Stepper interactions with onClick methods 2`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -204,6 +210,7 @@ exports[`Stepper Stepper interactions with onClick methods 3`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="false"
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
       tabindex="0"
@@ -224,6 +231,7 @@ exports[`Stepper Stepper interactions with onClick methods 3`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
       tabindex="0"
@@ -244,6 +252,7 @@ exports[`Stepper Stepper interactions with onClick methods 3`] = `
       </div>
     </div>
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -311,6 +320,7 @@ exports[`Stepper Stepper interactions with onClick methods 4`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="false"
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
       tabindex="0"
@@ -331,6 +341,7 @@ exports[`Stepper Stepper interactions with onClick methods 4`] = `
       </div>
     </div>
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -351,6 +362,7 @@ exports[`Stepper Stepper interactions with onClick methods 4`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -413,6 +425,7 @@ exports[`Stepper Stepper interactions with onClick methods 5`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -433,6 +446,7 @@ exports[`Stepper Stepper interactions with onClick methods 5`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -453,6 +467,7 @@ exports[`Stepper Stepper interactions with onClick methods 5`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -509,6 +524,7 @@ exports[`Stepper Stepper interactions with onClick methods 6`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -529,6 +545,7 @@ exports[`Stepper Stepper interactions with onClick methods 6`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -549,6 +566,7 @@ exports[`Stepper Stepper interactions with onClick methods 6`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -605,6 +623,7 @@ exports[`Stepper Stepper interactions with onClick methods 7`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -625,6 +644,7 @@ exports[`Stepper Stepper interactions with onClick methods 7`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -645,6 +665,7 @@ exports[`Stepper Stepper interactions with onClick methods 7`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -701,6 +722,7 @@ exports[`Stepper Stepper interactions with onClick methods 8`] = `
     class="stepper sgds"
   >
     <div
+      aria-current="false"
       class="stepper-item is-completed is-clickable"
       data-testid="sgds-step"
       tabindex="0"
@@ -721,6 +743,7 @@ exports[`Stepper Stepper interactions with onClick methods 8`] = `
       </div>
     </div>
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -741,6 +764,7 @@ exports[`Stepper Stepper interactions with onClick methods 8`] = `
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -803,6 +827,7 @@ exports[`Stepper default html structure, with minimal required stepMethods 1`] =
     class="stepper sgds"
   >
     <div
+      aria-current="step"
       class="stepper-item is-active"
       data-testid="sgds-step"
       tabindex="0"
@@ -823,6 +848,7 @@ exports[`Stepper default html structure, with minimal required stepMethods 1`] =
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"
@@ -843,6 +869,7 @@ exports[`Stepper default html structure, with minimal required stepMethods 1`] =
       </div>
     </div>
     <div
+      aria-current="false"
       class="stepper-item "
       data-testid="sgds-step"
       tabindex="0"


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

- [x] Going back to step 1 is only clickable and not keyboard accessible (can consider using `tabindex`).
- [x] Add `aria-current="step"` to the current step div to inform screen reader that this is their current step (currently, the only way to tell is by looking at the visual difference).