### PR TITLE
Implement a11y for Quantitytoggle

### DIFF
--- a/src/QuantityToggle/QuantityToggle.tsx
+++ b/src/QuantityToggle/QuantityToggle.tsx
@@ -89,6 +89,13 @@ export const QuantityToggle: BsPrefixRefForwardingComponent<
             }}
             min={0}
           />
+          <div
+            id="quantitytoggle-announcer"
+            role="region"
+            aria-live="assertive"
+            className="visually-hidden">
+            {count}
+          </div>
           <Button onClick={onPlus} {...buttonProps} aria-label="increment-button">
             <i className="bi bi-plus"></i>
           </Button>

--- a/src/QuantityToggle/QuantityToggle.tsx
+++ b/src/QuantityToggle/QuantityToggle.tsx
@@ -73,7 +73,7 @@ export const QuantityToggle: BsPrefixRefForwardingComponent<
       <>
         <FormLabel className="visually-hidden">quantity-toggle</FormLabel>
         <InputGroup size={size} variant="quantity-toggle">
-          <Button onClick={onMinus} {...buttonProps} aria-label="minus-btn">
+          <Button onClick={onMinus} {...buttonProps} aria-label="decrement-button">
             <i className="bi bi-dash"></i>
           </Button>
           <FormControl
@@ -89,7 +89,7 @@ export const QuantityToggle: BsPrefixRefForwardingComponent<
             }}
             min={0}
           />
-          <Button onClick={onPlus} {...buttonProps} aria-label="plus-btn">
+          <Button onClick={onPlus} {...buttonProps} aria-label="increment-button">
             <i className="bi bi-plus"></i>
           </Button>
         </InputGroup>

--- a/tests/QuantityToggle/QuantityToggle.test.tsx
+++ b/tests/QuantityToggle/QuantityToggle.test.tsx
@@ -12,12 +12,15 @@ describe('<QuantityToggle />', () => {
         const $InputGroup = container.querySelector('div')
         expect($InputGroup?.classList).toContain('input-group')
         expect($InputGroup).toHaveAttribute('variant', 'quantity-toggle')
-        expect($InputGroup?.children.length).toEqual(3)
+        expect($InputGroup?.children.length).toEqual(4)
         expect($InputGroup?.children[0].tagName).toEqual('BUTTON')
         expect($InputGroup?.children[0]).toHaveAttribute('aria-label', 'decrement-button')
         expect($InputGroup?.children[1].tagName).toEqual('INPUT')
-        expect($InputGroup?.children[2].tagName).toEqual('BUTTON')
-        expect($InputGroup?.children[2]).toHaveAttribute('aria-label', 'increment-button')
+        expect($InputGroup?.children[2].tagName).toEqual('DIV')
+        expect($InputGroup?.children[2]).toHaveAttribute('aria-live', 'assertive')
+        expect($InputGroup?.children[2]).toHaveClass('visually-hidden')
+        expect($InputGroup?.children[3].tagName).toEqual('BUTTON')
+        expect($InputGroup?.children[3]).toHaveAttribute('aria-label', 'increment-button')
 
 
         const $input = $InputGroup?.children[1]

--- a/tests/QuantityToggle/QuantityToggle.test.tsx
+++ b/tests/QuantityToggle/QuantityToggle.test.tsx
@@ -14,10 +14,10 @@ describe('<QuantityToggle />', () => {
         expect($InputGroup).toHaveAttribute('variant', 'quantity-toggle')
         expect($InputGroup?.children.length).toEqual(3)
         expect($InputGroup?.children[0].tagName).toEqual('BUTTON')
-        expect($InputGroup?.children[0]).toHaveAttribute('aria-label', 'minus-btn')
+        expect($InputGroup?.children[0]).toHaveAttribute('aria-label', 'decrement-button')
         expect($InputGroup?.children[1].tagName).toEqual('INPUT')
         expect($InputGroup?.children[2].tagName).toEqual('BUTTON')
-        expect($InputGroup?.children[2]).toHaveAttribute('aria-label', 'plus-btn')
+        expect($InputGroup?.children[2]).toHaveAttribute('aria-label', 'increment-button')
 
 
         const $input = $InputGroup?.children[1]

--- a/tests/QuantityToggle/__snapshots__/QuantityToggle.test.tsx.snap
+++ b/tests/QuantityToggle/__snapshots__/QuantityToggle.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<QuantityToggle /> has default structure 1`] = `
     variant="quantity-toggle"
   >
     <button
-      aria-label="minus-btn"
+      aria-label="decrement-button"
       class="btn btn-primary sgds"
       type="button"
     >
@@ -28,7 +28,7 @@ exports[`<QuantityToggle /> has default structure 1`] = `
       value="0"
     />
     <button
-      aria-label="plus-btn"
+      aria-label="increment-button"
       class="btn btn-primary sgds"
       type="button"
     >

--- a/tests/QuantityToggle/__snapshots__/QuantityToggle.test.tsx.snap
+++ b/tests/QuantityToggle/__snapshots__/QuantityToggle.test.tsx.snap
@@ -27,6 +27,14 @@ exports[`<QuantityToggle /> has default structure 1`] = `
       type="number"
       value="0"
     />
+    <div
+      aria-live="assertive"
+      class="visually-hidden"
+      id="quantitytoggle-announcer"
+      role="region"
+    >
+      0
+    </div>
     <button
       aria-label="increment-button"
       class="btn btn-primary sgds"


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

- [x] Change the `aria-label` for the minus and plus buttons using proper english words.
- [x] (Bonus) Add an announcer for screen reader users to know the count after every increment or decrement.
`<div id="announcer" role="region" aria-live="assertive" class="visually-hidden">{number}</div>`
