### PR TITLE
Implement a11y for Tooltip

### DIFF
--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -6,6 +6,7 @@ import OverlayTrigger from '../Overlay/OverlayTrigger';
 import TooltipBox from './TooltipBox';
 import CloseButton from '../CloseButton/CloseButton';
 import PropTypes from 'prop-types';
+import generateId from '../utils/generateId';
 
 export interface TooltipProps {
   /** The placement of the Tooltip in relation to its target */
@@ -35,15 +36,17 @@ const defaultProps: TooltipProps = {
   content: '',
 };
 
-export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps)=> {
+export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps) => {
   const { type, placement, content, children } = props;
   const [show, setShow] = useState(false);
   const target = useRef(null);
+  const toolTipId = generateId('tooltip', 'div');
   const clickToolTip = () => (
     <>
       {React.cloneElement(children as React.ReactElement, {
         onClick: () => setShow(!show),
         ref: target,
+        'aria-describedby': toolTipId,
       })}
       <Overlay target={target.current} show={show} placement={placement}>
         {(props) => (
@@ -52,6 +55,7 @@ export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps)=> {
             closeBtn={
               <CloseButton variant="white" onClick={() => setShow(!show)} />
             }
+            id={toolTipId}
           >
             {content}
           </TooltipBox>
@@ -59,14 +63,16 @@ export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps)=> {
       </Overlay>
     </>
   );
+  // console.log((children as React.ReactElement).props);
   const hoverTooltip = () => (
     <OverlayTrigger
       placement={placement}
-      overlay={<TooltipBox {...props}>{content}</TooltipBox>}
+      overlay={<TooltipBox id={toolTipId} {...props}>{content}</TooltipBox>}
     >
       {React.cloneElement(children as React.ReactElement, {
         onClick: () => setShow(!show),
         ref: target,
+        'aria-describedby': toolTipId,
       })}
     </OverlayTrigger>
   );

--- a/stories/Tooltip/Tooltip.stories.mdx
+++ b/stories/Tooltip/Tooltip.stories.mdx
@@ -113,3 +113,10 @@ The Tooltip can also be closed by clicking on the target element as well. Clicka
     </Tooltip>
   </Story>
 </Canvas>
+
+
+## Accessibility
+
+For tooltips to be accessible to keyboard and assistive technology users, you should only add tooltips to HTML elements that are keyboard-focusable and interactive (such as `<button>`, `<a>`). 
+
+Although non-semantic HTML elements (such as `<div>`, `<span>`) can be made focusable by adding the `tabindex="0"` attribute, this will add potentially annoying and confusing tab stops on non-interactive elements for keyboard users. In addition, most assistive technologies currently do not announce the tooltip in this situation.


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

- [x] Tooltip is not announced to screen reader users (Can explore using `aria-describedby` to associate the tooltip content with the main element.)
Example here: https://dequeuniversity.com/library/aria/tooltip