### PR TITLE
Implement a11y for Datepicker

### DIFF
--- a/src/DatePicker/Calendar.tsx
+++ b/src/DatePicker/Calendar.tsx
@@ -8,7 +8,7 @@ interface CalendarProps extends React.HTMLAttributes<HTMLTableElement> {
   mode: 'single' | 'range';
 }
 
-export const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+export const DAYS_LABEL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 export const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 export const setTimeToNoon = (date: Date) => {
@@ -130,16 +130,18 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
     }
 
     return (
-      <table className="text-center" ref={ref}>
+      <table className="text-center" role="grid" ref={ref}>
         <thead>
           <tr>
-            {DAY_LABELS.map((label: string, index: number) => {
+            {DAYS_LABEL.map((label: string, index: number) => {
               return (
-                <td
+                <th
                   key={index}
+                  abbr={label}
+                  scope="col"
                 >
-                  <small>{label}</small>
-                </td>
+                  <small>{label.slice(0, 3)}</small>
+                </th>
               );
             })}
           </tr>

--- a/src/DatePicker/Calendar.tsx
+++ b/src/DatePicker/Calendar.tsx
@@ -8,7 +8,7 @@ interface CalendarProps extends React.HTMLAttributes<HTMLTableElement> {
   mode: 'single' | 'range';
 }
 
-export const DAYS_LABEL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+export const DAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 export const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 export const setTimeToNoon = (date: Date) => {
@@ -133,7 +133,7 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
       <table className="text-center" role="grid" ref={ref}>
         <thead>
           <tr>
-            {DAYS_LABEL.map((label: string, index: number) => {
+            {DAY_LABELS.map((label: string, index: number) => {
               return (
                 <th
                   key={index}

--- a/src/DatePicker/CalendarHeader.tsx
+++ b/src/DatePicker/CalendarHeader.tsx
@@ -80,13 +80,18 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ ...props }) => {
   };
   return (
     <div className="text-center d-flex justify-content-between">
-      <i className="bi bi-chevron-left" onClick={handleClickPrevious}></i>
+      <button onClick={handleClickPrevious} aria-label={`previous ${view}`}>
+        <i className="bi bi-chevron-left"></i>
+      </button>
+      
 
-      <button onClick={changeView} disabled={view === 'year'}>
+      <button onClick={changeView} disabled={view === 'year'} aria-live='polite'>
         {renderHeader()}
       </button>
 
-      <i className="bi bi-chevron-right" onClick={handleClickNext}></i>
+      <button onClick={handleClickNext} aria-label={`next ${view}`}>
+        <i className="bi bi-chevron-right"></i>
+      </button>
     </div>
   );
 };

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import warning from 'warning';
 import FormControlToggle from '../Form/FormControlToggle';
 import { Dropdown } from '../Dropdown';
 import { ButtonVariant } from '../utils/types';
+import generateId from '../utils/generateId';
 
 export type CalendarPlacement = 'up' | 'down';
 export type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY/MM/DD';
@@ -375,17 +376,18 @@ export const DatePicker: BsPrefixRefForwardingComponent<
           );
       }
     }
+    const dropdownMenuId = generateId('combobox', 'ul');
     return (
       <DatePickerContext.Provider value={contextValue}>
         <Dropdown drop={calendarPlacement} className="form-control-group input-group">
-              <FormControlToggle {...controlProps} ref={formControlRef} />
+            <FormControlToggle {...controlProps} ref={formControlRef} role="combobox" aria-haspopup="dialog" aria-controls={dropdownMenuId} />
             <Button onClick={clear} disabled={props.disabled} variant={clearBtnVariant}>
               <i className="bi bi-x"></i>
               <span className="visually-hidden">clear</span>
             </Button>
             <i className="bi bi-calendar form-control-icon"></i>
 
-          <Dropdown.Menu className="sgds datepicker">
+          <Dropdown.Menu id={dropdownMenuId} className="sgds datepicker" role="dialog" aria-modal="true">
             <Dropdown.Header className="datepicker-header">
               {calendarHeader}
             </Dropdown.Header>

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -380,15 +380,15 @@ export const DatePicker: BsPrefixRefForwardingComponent<
     return (
       <DatePickerContext.Provider value={contextValue}>
         <Dropdown drop={calendarPlacement} className="form-control-group input-group">
-            <FormControlToggle {...controlProps} ref={formControlRef} role="combobox" aria-haspopup="dialog" aria-controls={dropdownMenuId} />
+            <FormControlToggle {...controlProps} ref={formControlRef} role="combobox" aria-haspopup="dialog" aria-controls={dropdownMenuId} aria-label="Choose Date" />
             <Button onClick={clear} disabled={props.disabled} variant={clearBtnVariant}>
               <i className="bi bi-x"></i>
               <span className="visually-hidden">clear</span>
             </Button>
             <i className="bi bi-calendar form-control-icon"></i>
 
-          <Dropdown.Menu id={dropdownMenuId} className="sgds datepicker" role="dialog" aria-modal="true">
-            <Dropdown.Header className="datepicker-header">
+          <Dropdown.Menu id={dropdownMenuId} className="sgds datepicker" as='div' role="dialog" aria-modal="true" aria-label="Choose Date">
+            <Dropdown.Header className="datepicker-header" role="none">
               {calendarHeader}
             </Dropdown.Header>
             <div className="datepicker-body">{BodyContent()}</div>

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -381,7 +381,7 @@ export const DatePicker: BsPrefixRefForwardingComponent<
       <DatePickerContext.Provider value={contextValue}>
         <Dropdown drop={calendarPlacement} className="form-control-group input-group">
             <FormControlToggle {...controlProps} ref={formControlRef} role="combobox" aria-haspopup="dialog" aria-controls={dropdownMenuId} aria-label="Choose Date" />
-            <Button onClick={clear} disabled={props.disabled} variant={clearBtnVariant}>
+            <Button onClick={clear} disabled={props.disabled} variant={clearBtnVariant} aria-label="Clear Selection">
               <i className="bi bi-x"></i>
               <span className="visually-hidden">clear</span>
             </Button>

--- a/tests/DatePicker/Calendar.test.tsx
+++ b/tests/DatePicker/Calendar.test.tsx
@@ -91,7 +91,7 @@ describe('Single mode Calendar', () => {
     );
     expect(container.querySelector('table.text-center')).toBeInTheDocument();
     DAY_LABELS.forEach((day) => {
-      expect(getByText(day)).toBeInTheDocument();
+      expect(getByText(day.slice(0, 3))).toBeInTheDocument();
     });
 
     const totalDaysInDisplayDate = daysInMonth[displayDate.getMonth()];

--- a/tests/DatePicker/CalendarHeader.test.tsx
+++ b/tests/DatePicker/CalendarHeader.test.tsx
@@ -23,11 +23,11 @@ describe('CalendarHeader', () => {
       container.querySelector('div.d-flex.text-center.justify-content-between')
     ).toBeInTheDocument();
     expect(
-      container.querySelector('div>i.bi.bi-chevron-left')
+      container.querySelector('div>button>i.bi.bi-chevron-left')
     ).toBeInTheDocument();
-    expect(container.querySelectorAll('button').length).toEqual(1);
+    expect(container.querySelectorAll('button').length).toEqual(3);
     expect(
-      container.querySelector('div>i.bi.bi-chevron-right')
+      container.querySelector('div>button>i.bi.bi-chevron-right')
     ).toBeInTheDocument();
 
     expect(getByText(`${displayMonth} ${displayYear}`)).toBeInTheDocument();
@@ -43,11 +43,11 @@ describe('CalendarHeader', () => {
         <CalendarHeader onChange={mockFn} displayDate={displayDate} />
       </DatePickerContext.Provider>
     );
-    const headerButton = container.querySelector('button');
+    const headerButton = container.querySelectorAll('button')[1];
     expect(headerButton?.textContent).toEqual(`${displayMonth} ${displayYear}`);
-    expect(container.querySelector('button')).not.toHaveAttribute('disabled');
+    expect(headerButton).not.toHaveAttribute('disabled');
 
-    fireEvent.click(container.querySelector('button')!);
+    fireEvent.click(headerButton!);
 
     await waitFor(() => {
       expect(contextValue.setView).toHaveBeenCalled();
@@ -63,14 +63,14 @@ describe('CalendarHeader', () => {
         <CalendarHeader onChange={mockFn} displayDate={displayDate} />
       </DatePickerContext.Provider>
     );
-    const headerButton = container.querySelector('button');
+    const headerButton = container.querySelectorAll('button')[1];
     expect(headerButton?.textContent).not.toEqual(
       `${displayMonth} ${displayYear}`
     );
     expect(headerButton?.textContent).toEqual(`${displayYear}`);
-    expect(container.querySelector('button')).not.toHaveAttribute('disabled');
+    expect(headerButton).not.toHaveAttribute('disabled');
 
-    fireEvent.click(container.querySelector('button')!);
+    fireEvent.click(headerButton!);
 
     await waitFor(() => {
       expect(contextValue.setView).toHaveBeenCalled();
@@ -86,7 +86,7 @@ describe('CalendarHeader', () => {
         <CalendarHeader onChange={mockFn} displayDate={displayDate} />
       </DatePickerContext.Provider>
     );
-    const headerButton = container.querySelector('button');
+    const headerButton = container.querySelectorAll('button')[1];
     expect(headerButton?.textContent).not.toEqual(
       `${displayMonth} ${displayYear}`
     );
@@ -94,9 +94,9 @@ describe('CalendarHeader', () => {
     expect(headerButton?.textContent).toEqual(
       `${displayDate.getFullYear() - 5} - ${displayDate.getFullYear() + 6}`
     );
-    expect(container.querySelector('button')).toHaveAttribute('disabled');
+    expect(headerButton).toHaveAttribute('disabled');
 
-    fireEvent.click(container.querySelector('button')!);
+    fireEvent.click(headerButton!);
 
     await waitFor(() => {
       expect(contextValue.setView).not.toHaveBeenCalled();

--- a/tests/DatePicker/__snapshots__/CalendarHeader.test.tsx.snap
+++ b/tests/DatePicker/__snapshots__/CalendarHeader.test.tsx.snap
@@ -5,15 +5,25 @@ exports[`CalendarHeader should have default html structure 1`] = `
   <div
     class="text-center d-flex justify-content-between"
   >
-    <i
-      class="bi bi-chevron-left"
-    />
-    <button>
+    <button
+      aria-label="previous day"
+    >
+      <i
+        class="bi bi-chevron-left"
+      />
+    </button>
+    <button
+      aria-live="polite"
+    >
       March 2022
     </button>
-    <i
-      class="bi bi-chevron-right"
-    />
+    <button
+      aria-label="next day"
+    >
+      <i
+        class="bi bi-chevron-right"
+      />
+    </button>
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
See slack channel 'sgds-react-a11y' on a11y recommendations

Current datepicker is not keyboard and screen reader accessible.
Example here: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/

- [x] Add relevant aria roles
- [x] Wrap `<` and `>` icons with `<button>`

_Good to have:_
Use javascript to focus on datepicker dropdown when dropdown is shown --> a major addition, also for components that have popups (e.g. modals, combobox etc).