### PR TITLE
Create multi-select mode for Combobox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
         "typescript": "^4.5.4",
-        "wait-on": "^7.0.1",
         "yup": "^0.32.11"
       },
       "engines": {
@@ -2826,21 +2825,6 @@
         "react-dom": ">=17.0.2"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "dev": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "node_modules/@hypnosphi/create-react-context": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
@@ -4828,27 +4812,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -9429,30 +9392,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -15868,26 +15807,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -21918,19 +21837,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/joi": {
-      "version": "17.10.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.10.2.tgz",
-      "integrity": "sha512-hcVhjBxRNW/is3nNLdGLIjkgXetkeGc2wyhydhz8KumG23Aerk4HPjU5zaPAMRqXQFc0xNqXTC7+zQjxr0GlKA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-string-escape": {
@@ -31216,25 +31122,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -34539,21 +34426,6 @@
         "@govtechsg/sgds-masthead": "^0.0.16"
       }
     },
-    "@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "dev": true
-    },
-    "@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "@hypnosphi/create-react-context": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
@@ -36079,27 +35951,6 @@
           "dev": true
         }
       }
-    },
-    "@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true
-    },
-    "@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.6",
@@ -39630,29 +39481,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -44641,12 +44469,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -49245,19 +49067,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "joi": {
-      "version": "17.10.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.10.2.tgz",
-      "integrity": "sha512-hcVhjBxRNW/is3nNLdGLIjkgXetkeGc2wyhydhz8KumG23Aerk4HPjU5zaPAMRqXQFc0xNqXTC7+zQjxr0GlKA==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-string-escape": {
@@ -56566,19 +56375,6 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
-      }
-    },
-    "wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
       }
     },
     "walker": {

--- a/src/Combobox/Combobox.tsx
+++ b/src/Combobox/Combobox.tsx
@@ -150,7 +150,6 @@ export const Combobox: BsPrefixRefForwardingComponent<
       if (e.key === 'Backspace' && prevInput.length === 0 && state.selectedItems.length > 0) {
         const prevSelectedItem = state.selectedItems.slice(-1)[0];
         removeSelectedItem(prevSelectedItem)(e)
-        if (!menuOpen) comboboxControlRef.current?.click()
       }
     }
 
@@ -187,9 +186,15 @@ export const Combobox: BsPrefixRefForwardingComponent<
       });
     };
 
+    /**
+     * To remove selected item. Only applicable for multi-select combobox.
+     */
     const removeSelectedItem = (itemToRemove: string) =>
       (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLInputElement>) => {
+        // To make sure dropdown menu does not get toggled
         e.stopPropagation();
+
+        if (!menuOpen) comboboxControlRef.current?.click()
 
         const newSelectedItems = state.selectedItems.filter(item => item !== itemToRemove)
 

--- a/src/Combobox/Combobox.tsx
+++ b/src/Combobox/Combobox.tsx
@@ -11,8 +11,10 @@ import Dropdown from '../Dropdown/Dropdown';
 import FormControlToggle from '../Form/FormControlToggle';
 import classNames from 'classnames';
 import generateId from '../utils/generateId';
+import SelectedItem from './SelectedItem';
 
 export type MenuPlacement = 'up' | 'down';
+export type ComboboxMode = 'single' | 'multi';
 
 export interface ComboboxProps extends Omit<FormControlProps, 'type'> {
   /**Initial value of input */
@@ -24,33 +26,51 @@ export interface ComboboxProps extends Omit<FormControlProps, 'type'> {
   /** The onChange handler for Combobox's input change */
   onChangeInput?: (
     val: string,
-    e?: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLLIElement>
+    e?: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>
+  ) => void;
+  /** The onChange handler when selection changes. 
+   *  For multi-selection mode, this handler is also called when user removes a selection. */
+  onChangeSelect?: (
+    item: string,
+    items: string[],
+    e?: React.MouseEvent<HTMLButtonElement>
   ) => void;
   /** Adds a FormLabel to `<Combobox />` */
   label?: string;
-    /** Adds icon defined to FormControl */
+  /** Adds icon defined to FormControl */
   icon?: React.ReactElement;
+  /** Single or multi-selection */
+  mode?: ComboboxMode;
 }
 
 const propTypes = {
   initialValue: PropTypes.string,
   onChangeInput: PropTypes.func,
+  onChangeSelect: PropTypes.func,
   menuPlacement: PropTypes.oneOf<MenuPlacement>(['up', 'down']),
   menuList: PropTypes.arrayOf(PropTypes.string).isRequired,
   label: PropTypes.string,
-  icon: PropTypes.element
+  icon: PropTypes.element,
+  mode: PropTypes.oneOf<ComboboxMode>(['single', 'multi'])
 };
 
 interface ComboboxState {
   value: string;
   invalid: boolean;
   menuList: string[];
+  selectedItems: string[];
 }
 
 const defaultProps: Partial<ComboboxProps> = {
   menuPlacement: 'down',
   initialValue: '',
+  label: '',
+  mode: 'single'
 };
+
+const removeDuplicates = (arr: any[]) => {
+  return arr.filter((item: any, index: number) => arr.indexOf(item) === index);
+}
 
 export const Combobox: BsPrefixRefForwardingComponent<
   'input',
@@ -62,8 +82,10 @@ export const Combobox: BsPrefixRefForwardingComponent<
       menuList,
       initialValue = '',
       onChangeInput,
+      onChangeSelect,
       label = '',
       icon,
+      mode = 'single',
       ...props
     },
     ref
@@ -78,27 +100,37 @@ export const Combobox: BsPrefixRefForwardingComponent<
       value: initialValue,
       invalid: false,
       menuList: initialValue
-        ? menuList.filter((n) =>
-            n.toLowerCase().startsWith(initialValue.toLowerCase())
-          )
-        : menuList,
+        ? removeDuplicates(menuList).filter((n) =>
+          n.toLowerCase().startsWith(initialValue.toLowerCase())
+        )
+        : removeDuplicates(menuList),
+      selectedItems: menuList.includes(initialValue) ? [initialValue] : []
     };
     const [state, setState] = useState(initialState);
+
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!menuOpen) {
         formControlRef.current?.click();
       }
-      const filterMenuList = menuList.filter((n) => {
-        const nLowerCase = n.toLowerCase();
-        const valueLower = e.currentTarget.value.toLowerCase();
-        return nLowerCase.startsWith(valueLower);
-      });
+      const newInput = e.currentTarget.value;
+
+      const newSelectedItems =
+        mode === 'single' && menuList.includes(newInput) && !state.selectedItems.includes(newInput)
+          ? [newInput]
+          : (mode === 'single' ? [] : state.selectedItems)
+
+      const newMenuList = mode === 'single'
+        ? filterMenuList(removeDuplicates(menuList), newInput)
+        : filterMenuList(removeDuplicates(menuList), newInput)
+          .filter(item => !newSelectedItems.includes(item))
+
       setState({
         ...state,
-        value: e.currentTarget.value,
-        menuList: filterMenuList,
+        value: newInput,
+        menuList: newMenuList,
+        selectedItems: newSelectedItems
       });
-      if (onChangeInput) onChangeInput(e.currentTarget.value, e);
+      if (onChangeInput) onChangeInput(newInput, e);
     };
 
     const controlProps = {
@@ -109,17 +141,51 @@ export const Combobox: BsPrefixRefForwardingComponent<
       ...props,
     };
 
-    const handleClickItem = (e: React.MouseEvent<HTMLLIElement>) => {
-      if (onChangeInput) onChangeInput(e.currentTarget.textContent!, e);
+    const filterMenuList = (menuList: string[], input: string) => {
+      return menuList.filter(item => item.toLowerCase().startsWith(input.toLowerCase()))
+    }
+
+    const handleClickItem = (e: React.MouseEvent<HTMLButtonElement>) => {
+      const selectedItem = e.currentTarget.textContent!
+
+      const newInput = mode === 'single' ? selectedItem : ''
+
+      const newSelectedItems = mode === 'single'
+        ? [selectedItem]
+        : (state.selectedItems.includes(selectedItem)
+          ? state.selectedItems
+          : [...state.selectedItems, selectedItem])
+
+      const newMenuList = mode === 'single'
+        ? filterMenuList(removeDuplicates(menuList), newInput)
+        : removeDuplicates(menuList)
+          .filter(item => !newSelectedItems.includes(item))
+
+      if (onChangeInput) onChangeInput(selectedItem, e);
+      if (onChangeSelect) onChangeSelect(selectedItem, newSelectedItems, e)
 
       setState({
         ...state,
-        value: e.currentTarget.textContent as string,
-        menuList: state.menuList.filter(
-          (c) => c === e.currentTarget.textContent!
-        ),
+        value: newInput,
+        menuList: newMenuList,
+        selectedItems: newSelectedItems
       });
     };
+
+    const removeSelectedItem = (itemToRemove: string) => (e: React.MouseEvent<HTMLButtonElement>) => {
+      const newSelectedItems = state.selectedItems.filter(item => item !== itemToRemove)
+
+      const newMenuList = filterMenuList(removeDuplicates(menuList), state.value)
+        .filter(item => !newSelectedItems.includes(item))
+
+      if (onChangeSelect) onChangeSelect(itemToRemove, newSelectedItems, e)
+
+      setState({
+        ...state,
+        menuList: newMenuList,
+        selectedItems: newSelectedItems
+      })
+    }
 
     const focusDropdownItem = (event: React.FocusEvent<HTMLAnchorElement>) => {
       setState({
@@ -140,11 +206,54 @@ export const Combobox: BsPrefixRefForwardingComponent<
           focusFirstItemOnShow={false}
           drop={menuPlacement}
         >
-          <FormControlToggle {...controlProps} setIsMenuOpen={setIsMenuOpen} role="combobox" aria-autocomplete="list" aria-controls={comboboxMenuId}/>
-          {icon &&
-            React.cloneElement(icon, {
-              className: classNames(icon.props.className, 'form-control-icon'),
-            })}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              paddingLeft: "0",
+              paddingRight: "0"
+            }}
+            className='form-control'>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                alignItems: "center",
+                flex: "1 1 0%",
+                gap: "2px",
+                overflow: "hidden"
+              }}>
+
+              {mode === 'multi'
+                && state.selectedItems.map((item, idx) => {
+                  return <SelectedItem
+                    key={idx}
+                    label={item}
+                    onRemove={removeSelectedItem(item)} />
+                })}
+
+              <FormControlToggle
+                style={{
+                  border: "none",
+                  boxShadow: "none",
+                  width: "auto",
+                  flex: "1 1 auto"
+                }} 
+                {...controlProps} 
+                setIsMenuOpen={setIsMenuOpen} 
+                role="combobox" 
+                aria-autocomplete="list" 
+                aria-controls={comboboxMenuId} />
+            </div>
+
+            {icon &&
+              React.cloneElement(icon, {
+                className: classNames(icon.props.className, 'form-control-icon'),
+                style: { position: "static", float: "right" }
+              })}
+          </div>
+
+
           {state.menuList.length > 0 && (
             <DropdownMenu id={comboboxMenuId} role="listbox">
               {state.menuList.map((menuItem) => (

--- a/src/Combobox/ComboboxToggle.tsx
+++ b/src/Combobox/ComboboxToggle.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { useDropdownToggle } from '@restart/ui/DropdownToggle';
+import {
+  BsPrefixProps,
+  BsPrefixRefForwardingComponent,
+} from '../utils/helpers';
+import useWrappedRefWithWarning from '../utils/useWrappedRefWithWarning';
+import useMergedRefs from '@restart/hooks/useMergedRefs';
+import DropdownContext from '@restart/ui/DropdownContext';
+
+export interface ComboboxToggleProps extends BsPrefixProps, React.HTMLAttributes<HTMLDivElement> {
+  as?: React.ElementType;
+  setIsMenuOpen: Function;
+}
+
+type ComboboxToggleComponent = BsPrefixRefForwardingComponent<
+  'div',
+  ComboboxToggleProps
+>;
+
+const ComboboxToggle: ComboboxToggleComponent = React.forwardRef(
+  (
+    {
+      as: Component = 'div',
+      setIsMenuOpen,
+      ...props
+    }: ComboboxToggleProps,
+    ref
+  ) => {
+    const [toggleProps] = useDropdownToggle();
+    toggleProps.ref = useMergedRefs(
+      toggleProps.ref,
+      useWrappedRefWithWarning(ref, 'DropdownToggle')
+    );
+
+    const dropdownContext = React.useContext(DropdownContext);
+
+    const { "aria-expanded": ariaExpanded, id, ...newToggleProps } = toggleProps
+    
+
+    if (setIsMenuOpen) {
+      React.useEffect(() => {
+        setIsMenuOpen(dropdownContext?.show);
+      }, [dropdownContext?.show]);
+    }
+    
+    return (
+      <Component
+        className="form-control"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          paddingLeft: "0",
+          paddingRight: "0"
+        }}
+        {...newToggleProps}
+        {...props}
+      />
+    );
+  }
+);
+
+export default ComboboxToggle;

--- a/src/Combobox/SelectedItem.tsx
+++ b/src/Combobox/SelectedItem.tsx
@@ -27,6 +27,7 @@ const SelectedItem = ({ ...props }: SelectedItemProps) => {
       </span>
       <Button
         onClick={props.onRemove}
+        aria-label={`Remove ${props.label}`}
         style={{ padding: "0" }}>
         <i className="bi bi-x"></i>
       </Button>

--- a/src/Combobox/SelectedItem.tsx
+++ b/src/Combobox/SelectedItem.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Button } from '../Button';
+
+interface SelectedItemProps {
+  label: string;
+  onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const SelectedItem = ({ ...props }: SelectedItemProps) => {
+  return (
+    <div
+      style={{ 
+        display: "flex", 
+        height: "fit-content", 
+        borderRadius: "2px", 
+        margin: "2px" }} 
+      className="bg-primary">
+      <span
+        style={{ 
+          display: "flex", 
+          alignItems: "center", 
+          whiteSpace: "initial", 
+          overflow: "hidden", 
+          textOverflow: "ellipsis" }}
+        className="badge bg-primary sgds">
+        {props.label}
+      </span>
+      <Button
+        onClick={props.onRemove}
+        style={{ padding: "0" }}>
+        <i className="bi bi-x"></i>
+      </Button>
+    </div>
+  )
+}
+
+export default SelectedItem;

--- a/src/Combobox/index.ts
+++ b/src/Combobox/index.ts
@@ -1,3 +1,3 @@
 export { default as Combobox } from './Combobox';
-export type { ComboboxProps as TypeaheadProps, MenuPlacement } from './Combobox';
+export type { ComboboxProps as TypeaheadProps, MenuPlacement, ComboboxMode } from './Combobox';
 

--- a/src/Dropdown/DropdownMenu.tsx
+++ b/src/Dropdown/DropdownMenu.tsx
@@ -72,6 +72,11 @@ export interface DropdownMenuProps
 
   /** `@private` Provides context when used in NavDropdown component  */
   isNav?: boolean;
+
+  /**
+   * `@private` The list of items in the menu
+   */
+  menuItems?: string[];
 }
 
 const propTypes = {
@@ -134,6 +139,11 @@ const propTypes = {
 
   /** @private Provides context when used in NavDropdown component  */
   isNav: PropTypes.bool,
+
+  /**
+   * `@private` The list of items in the menu.
+   */
+  menuItems: PropTypes.arrayOf(PropTypes.string),
 };
 
 const defaultProps: Partial<DropdownMenuProps> = {
@@ -181,6 +191,7 @@ export const DropdownMenu: BsPrefixRefForwardingComponent<
       popperConfig,
       variant,
       isNav,
+      menuItems,
       ...props
     },
     ref
@@ -238,6 +249,10 @@ export const DropdownMenu: BsPrefixRefForwardingComponent<
       // renderOnMount=true. Need to call update() to correct it.
       if (show) popper?.update();
     }, [show]);
+
+    useIsomorphicEffect(() => {
+      popper?.update();
+    }, [menuItems]);
 
     if (!hasShown && !renderOnMount && !isInputGroup) return null;
 

--- a/src/Form/FormControlToggle.tsx
+++ b/src/Form/FormControlToggle.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useContext } from 'react';
 import { useDropdownToggle } from '@restart/ui/DropdownToggle';
-import DropdownContext from '@restart/ui/DropdownContext';
 import useMergedRefs from '@restart/hooks/useMergedRefs';
 import InputGroupContext from '../InputGroup/InputGroupContext';
 import useWrappedRefWithWarning from '../utils/useWrappedRefWithWarning';
@@ -13,7 +12,6 @@ import FormControl, { FormControlProps } from './FormControl';
 export interface FormControlToggleProps extends Omit<FormControlProps, 'type'> {
   as?: React.ElementType;
   childBsPrefix?: string;
-  setIsMenuOpen?: Function;
 }
 
 type FormControlToggleComponent = BsPrefixRefForwardingComponent<
@@ -51,7 +49,6 @@ const FormControlToggle: FormControlToggleComponent = React.forwardRef(
       bsPrefix,
       className,
       childBsPrefix,
-      setIsMenuOpen,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = FormControl,
       ...props
@@ -59,7 +56,6 @@ const FormControlToggle: FormControlToggleComponent = React.forwardRef(
     ref
   ) => {
     const prefix = 'dropdown-toggle';
-    const dropdownContext = useContext(DropdownContext);
     const isInputGroup = useContext(InputGroupContext);
     if (childBsPrefix !== undefined) {
       (props as any).bsPrefix = childBsPrefix;
@@ -71,11 +67,6 @@ const FormControlToggle: FormControlToggleComponent = React.forwardRef(
     );
     const {"aria-expanded": ariaExpanded, id, ...newToggleProps} = toggleProps
 
-    if (setIsMenuOpen) {
-      React.useEffect(() => {
-        setIsMenuOpen(dropdownContext?.show);
-      }, [dropdownContext?.show]);
-    }
     // This intentionally forwards size and variant (if set) to the
     // underlying component, to allow it to render size and style variants.
     return (
@@ -83,7 +74,7 @@ const FormControlToggle: FormControlToggleComponent = React.forwardRef(
         className={classNames(
           className,
           prefix,
-          !!isInputGroup && dropdownContext?.show && 'show'
+          !!isInputGroup
         )}
         {...newToggleProps}
         {...props}

--- a/stories/Combobox/Combobox.stories.mdx
+++ b/stories/Combobox/Combobox.stories.mdx
@@ -215,6 +215,7 @@ export const ComboboxTemplate = (args) => {
   return (
     <Combobox
       {...args}
+      label='Select a country'
       menuList={menuList}
       id="typeaheadExample"
       icon={<i className="bi bi-search"></i>}
@@ -227,13 +228,11 @@ export const ComboboxTemplate = (args) => {
 `Combobox` is a built using `Dropdown`, `Dropdown.Menu`, `Dropdown.Item` and `FormControl` that doubles up as a toggle.
 `ComboboxProps` extends `FormControlProps`.
 
-<Story
-  name="Default"
-  args={{ label: 'Select a country' }}
-  parameters={{ docs: { source: { type: 'code' } } }}
->
-  {ComboboxTemplate.bind({})}
-</Story>
+<Canvas>
+  <Story name="Default">
+    {ComboboxTemplate.bind({})}
+  </Story>
+</Canvas>
 
 <br />
 
@@ -245,22 +244,6 @@ import { Combobox } from '@govtechsg/sgds-react/Combobox';
 
 <ArgsTable story="Default" />
 
-### Code Sample
-
-```jsx
-import { Combobox, ComboboxProps } from '@govtechsg/sgds-react/Combobox';
-
-export const ComboboxComponent = () => {
-  const menuList = ['apple', 'orange', 'banana'];
-  return (
-    <Combobox
-      menuList={menuList}
-      id="typeaheadExample"
-      icon={<i className="bi bi-search"></i>}
-    />
-  );
-};
-```
 
 ## Single-select Combobox
 By default (mode='single'), only a maximum of one item can be selected at any time.
@@ -269,6 +252,7 @@ export const SingleSelectCombobox = () => {
   const menuList = ['apple', 'orange', 'banana'];
   return (
     <Combobox
+      label="Select a fruit"
       menuList={menuList}
       id="typeaheadExample"
       icon={<i className="bi bi-search"></i>}
@@ -276,7 +260,11 @@ export const SingleSelectCombobox = () => {
   );
 };
 
-<Story name="Single-select">{SingleSelectCombobox.bind({})}</Story>
+<Canvas>
+  <Story name="Single-select">
+    {SingleSelectCombobox.bind({})}
+  </Story>
+</Canvas>
 
 
 ## Multi-select Combobox
@@ -286,6 +274,7 @@ export const MultiSelectCombobox = () => {
   const menuList = ['apple', 'orange', 'banana'];
   return (
     <Combobox
+      label="Select some fruits"
       mode="multi"
       menuList={menuList}
       id="typeaheadExample"
@@ -294,7 +283,12 @@ export const MultiSelectCombobox = () => {
   );
 };
 
-<Story name="Multi-select">{MultiSelectCombobox.bind({})}</Story>
+<Canvas>
+  <Story name="Multi-select">
+    {MultiSelectCombobox.bind({})}
+  </Story>
+</Canvas>
+
 
 ## onChangeInput
 
@@ -324,7 +318,12 @@ export const ComboboxOnChangeInputTemplate = () => {
   );
 };
 
-<Story name="onChangeInput">{ComboboxOnChangeInputTemplate.bind({})}</Story>
+<Canvas>
+  <Story name="onChangeInput">
+    {ComboboxOnChangeInputTemplate.bind({})}
+  </Story>
+</Canvas>
+
 
 ## onChangeSelect
 
@@ -360,30 +359,8 @@ export const ComboboxOnChangeSelectTemplate = () => {
   );
 };
 
-<Story name="onChangeSelect">{ComboboxOnChangeSelectTemplate.bind({})}</Story>
-
-### Code Sample
-
-```jsx
-import { Combobox } from '@govtechsg/sgds-react/Combobox';
-
-export const ComboboxComponent = () => {
-  const menuList = ['apple', 'orange', 'banana'];
-  const [fruits, setFruits] = useState('');
-  const handleChange = (val, e) => {
-    setFruits(val);
-  };
-  return (
-    <>
-      <Combobox
-        menuList={menuList}
-        onChangeInput={handleChange}
-        label="Select a fruit"
-        id="typeaheadExample"
-        icon={<i className="bi bi-search"></i>}
-      />
-      <div>Selected fruits : {fruits}</div>
-    </>
-  );
-};
-```
+<Canvas>
+  <Story name="onChangeSelect">
+    {ComboboxOnChangeSelectTemplate.bind({})}
+  </Story>
+</Canvas>

--- a/stories/Combobox/Combobox.stories.mdx
+++ b/stories/Combobox/Combobox.stories.mdx
@@ -262,13 +262,49 @@ export const ComboboxComponent = () => {
 };
 ```
 
+## Single-select Combobox
+By default (mode='single'), only a maximum of one item can be selected at any time.
+
+export const SingleSelectCombobox = () => {
+  const menuList = ['apple', 'orange', 'banana'];
+  return (
+    <Combobox
+      menuList={menuList}
+      id="typeaheadExample"
+      icon={<i className="bi bi-search"></i>}
+    />
+  );
+};
+
+<Story name="Single-select">{SingleSelectCombobox.bind({})}</Story>
+
+
+## Multi-select Combobox
+When mode='multi', multiple items can be selected.
+
+export const MultiSelectCombobox = () => {
+  const menuList = ['apple', 'orange', 'banana'];
+  return (
+    <Combobox
+      mode="multi"
+      menuList={menuList}
+      id="typeaheadExample"
+      icon={<i className="bi bi-search"></i>}
+    />
+  );
+};
+
+<Story name="Multi-select">{MultiSelectCombobox.bind({})}</Story>
+
 ## onChangeInput
 
 `onChangeInput` is fired whenever the value of input changes whether due to typing directly in the input or from selection from menu.
-The first argument of `onChangeInput` returns the string value of the input.
-The second argument returns either the ChangeEvent or MouseEvent depending on the type of user interaction with `<Combobox/>`
 
-export const ComboboxOnChangeTemplate = () => {
+The first argument of `onChangeInput` returns the string value of the input.
+
+The second argument returns either the ChangeEvent or MouseEvent depending on the type of user interaction with `<Combobox/>`.
+
+export const ComboboxOnChangeInputTemplate = () => {
   const [fruits, setFruits] = useState('');
   const handleChange = (val, e) => {
     setFruits(val);
@@ -288,7 +324,43 @@ export const ComboboxOnChangeTemplate = () => {
   );
 };
 
-<Story name="onChangeInput">{ComboboxOnChangeTemplate.bind({})}</Story>
+<Story name="onChangeInput">{ComboboxOnChangeInputTemplate.bind({})}</Story>
+
+## onChangeSelect
+
+`onChangeSelect` is fired whenever a menu item is selected, or when an item gets removed from selection (in the case of 'multi-select' combobox).
+
+The first argument of `onChangeSelect` returns the string value of the item that is selected or unselected.
+
+The second argument returns the string array of the updated list of selected items. For the case of 'single-select' combobox, only a maximum one item can be selected. Hence the maximum length of the array is 1.
+
+The third argument returns either the MouseEvent or KeyboardEvent depending on the type of user interaction with `<Combobox/>`.
+
+export const ComboboxOnChangeSelectTemplate = () => {
+  const [fruit, setFruit] = useState('')
+  const [fruits, setFruits] = useState([]);
+  const handleSelect = (item, items, e) => {
+    setFruit(item);
+    setFruits(items);
+  };
+  const menuList = ['apple', 'orange', 'banana'];
+  return (
+    <>
+      <Combobox
+        menuList={menuList}
+        onChangeSelect={handleSelect}
+        mode='multi'
+        label="Select a fruit"
+        id="typeaheadExample"
+        icon={<i className="bi bi-search"></i>}
+      />
+      <div>Previous selected/unselected fruit : {fruit}</div>
+      <div>Selected fruits : {fruits.join(', ')}</div>
+    </>
+  );
+};
+
+<Story name="onChangeSelect">{ComboboxOnChangeSelectTemplate.bind({})}</Story>
 
 ### Code Sample
 

--- a/tests/Combobox/Combobox.test.tsx
+++ b/tests/Combobox/Combobox.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { Combobox } from '../../src';
 const menuList = [
@@ -209,15 +209,15 @@ const menuList = [
   'Zimbabwe',
 ];
 
-describe('<Combobox> a11y', () => {
-  it('form control has role="combobox" on input element', async () => {
+describe('Combobox a11y', () => {
+  it('has role="combobox"', async () => {
     const { container } = render(<Combobox menuList={menuList} />);
-    expect(container.querySelector('input.form-control')).toHaveAttribute(
+    expect(container.querySelector('div.form-control')).toHaveAttribute(
       'role',
       'combobox'
     );
   });
-  it('form control has aria-autocomplete="list" on input element', async () => {
+  it('input element has aria-autocomplete="list"', async () => {
     const { container } = render(<Combobox menuList={menuList} />);
     expect(container.querySelector('input.form-control')).toHaveAttribute(
       'aria-autocomplete',
@@ -227,38 +227,36 @@ describe('<Combobox> a11y', () => {
   it('dropdown menu has role="listbox" on ul element', async () => {
     const { container } = render(<Combobox menuList={menuList} />);
     fireEvent.click(container
-      .querySelector('input.form-control')!)
+      .querySelector('div.form-control')!)
     expect(container.querySelector('ul.dropdown-menu')).toHaveAttribute(
       'role',
       'listbox'
     );
   });
-  it('form control input aria-controls id points to ul id', async () => {
+  it('aria-controls id points to ul (dropdown menu) id', async () => {
     const { container } = render(<Combobox menuList={menuList} />);
     fireEvent.click(container
-      .querySelector('input.form-control')!)
+      .querySelector('div.form-control')!)
     const menuUlId = container.querySelector('ul')?.getAttribute('id');
     const inputAriaControlValue = container
-      .querySelector('input.form-control')
+      .querySelector('div.form-control')
       ?.getAttribute('aria-controls');
 
-      expect(inputAriaControlValue).toEqual(menuUlId);
+    expect(inputAriaControlValue).toEqual(menuUlId);
   });
 });
-describe('<Combobox>', () => {
+
+describe('Single & multi-select Combobox shared behavior', () => {
   it('renders default HTML of dropdown', async () => {
     const { container, getByText } = render(<Combobox menuList={menuList} />);
     expect(container.firstElementChild?.classList).toContain('dropdown');
     expect(container.firstElementChild?.classList).toContain('dropdown');
     expect(container.firstElementChild?.tagName).toContain('DIV');
-    expect(
-      container.querySelector('input.form-control.dropdown-toggle')
-    ).toBeInTheDocument();
+    expect(container.querySelector('input')).toBeInTheDocument();
     expect(container.querySelector('ul.dropdown-menu')).not.toBeInTheDocument();
 
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
+
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
@@ -271,9 +269,8 @@ describe('<Combobox>', () => {
       <Combobox menuList={menuList} initialValue="test" />
     );
     expect(container.querySelector('input')?.value).toEqual('test');
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
+
     //menu shouldnt appear if initialValue doesnt match any in menuList
     await waitFor(() => {
       expect(
@@ -288,9 +285,8 @@ describe('<Combobox>', () => {
     );
     expect(container.querySelector('input')?.value).toEqual('Afghanistan');
 
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
+
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
@@ -302,9 +298,8 @@ describe('<Combobox>', () => {
     );
     expect(container.querySelector('input')?.value).toEqual('afghanistan');
 
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
+
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
@@ -316,9 +311,8 @@ describe('<Combobox>', () => {
     );
     expect(container.querySelector('input')?.value).toEqual('a');
 
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
+
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
@@ -334,9 +328,8 @@ describe('<Combobox>', () => {
     );
     expect(container.querySelector('input')?.value).toEqual('a');
 
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
+
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
@@ -352,27 +345,19 @@ describe('<Combobox>', () => {
     const { container, getByText, queryByText } = render(
       <Combobox menuList={menuList} />
     );
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
     });
 
-    fireEvent.change(
-      container.querySelector('input.form-control.dropdown-toggle')!,
-      { target: { value: 's' } }
-    );
+    fireEvent.change(container.querySelector('input')!, { target: { value: 's' } });
 
     await waitFor(() => {
       expect(getByText('Samoa')).toBeInTheDocument();
       expect(queryByText('Afghanistan')).toBeNull();
     });
-    fireEvent.change(
-      container.querySelector('input.form-control.dropdown-toggle')!,
-      { target: { value: 'si' } }
-    );
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'si' } });
     await waitFor(() => {
       expect(queryByText('Samoa')).toBeNull();
       expect(getByText('Singapore')).toBeInTheDocument();
@@ -382,18 +367,13 @@ describe('<Combobox>', () => {
 
   it('key press arrowDown scrolls menu and changes input', async () => {
     const { container, getByText } = render(<Combobox menuList={menuList} />);
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
       expect(getByText('Afghanistan')).toBeInTheDocument();
     });
 
-    fireEvent.keyDown(
-      container.querySelector('input.form-control.dropdown-toggle')!,
-      { key: 'ArrowDown', code: 'ArrowDown' }
-    );
+    fireEvent.keyDown(container.querySelector('input')!, { key: 'ArrowDown', code: 'ArrowDown' });
 
     await waitFor(() => {
       expect(container.querySelector('input')?.value).toEqual('Afghanistan');
@@ -414,30 +394,11 @@ describe('<Combobox>', () => {
     });
   });
 
-  it('onChangeInput fires when input changes', async () => {
-    const mockFn = jest.fn();
-    const { container } = render(
-      <Combobox menuList={menuList} onChangeInput={mockFn} />
-    );
-    fireEvent.change(
-      container.querySelector('input.form-control.dropdown-toggle')!,
-      { target: { value: 's' } }
-    );
-    await waitFor(() => expect(mockFn).toBeCalledTimes(1));
-    fireEvent.change(
-      container.querySelector('input.form-control.dropdown-toggle')!,
-      { target: { value: 'si' } }
-    );
-    await waitFor(() => expect(mockFn).toBeCalledTimes(2));
-  });
-
   it('pass in menuPlacement changes data-popper-placement attri', async () => {
     const { container } = render(
       <Combobox menuList={menuList} menuPlacement="up" />
     );
-    fireEvent.click(
-      container.querySelector('input.form-control.dropdown-toggle')!
-    );
+    fireEvent.click(container.querySelector('div.form-control')!);
     await waitFor(() => {
       expect(container.querySelector('ul.dropdown-menu')).toHaveAttribute(
         'x-placement',
@@ -472,4 +433,219 @@ describe('<Combobox>', () => {
       )
     ).toBeInTheDocument();
   });
+});
+
+describe('Multi-select Combobox dropdown menu', () => {
+  it('dropdown menu remains open when an item is selected', async () => {
+    const { container } = render(<Combobox menuList={menuList} mode='multi' />);
+
+    fireEvent.click(container.querySelector('div.form-control')!);
+    await waitFor(() => {
+      expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
+    });
+
+    // Selecting an item
+    fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+      ).toBeInTheDocument();
+    });
+
+    // dropdown menu should remain open
+    expect(container.querySelector('ul.dropdown-menu.show')).toBeInTheDocument();
+  });
+
+  it('dropdown menu remains open when an item is unselected', async () => {
+    const { container } = render(<Combobox menuList={menuList} mode='multi' />);
+
+    fireEvent.click(container.querySelector('div.form-control')!);
+    await waitFor(() => {
+      expect(container.querySelector('ul.dropdown-menu.show')).toBeInTheDocument();
+    });
+
+    // Selecting an item
+    fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+      ).toBeInTheDocument();
+    });
+
+    // Close the dropdown menu
+    fireEvent.click(container.querySelector('div.form-control')!);
+    await waitFor(() => {
+      expect(container.querySelector('ul.dropdown-menu.show')).not.toBeInTheDocument();
+    });
+
+    // Unselecting the item
+    fireEvent.click(screen.getByLabelText('Remove Afghanistan', { selector: 'button' }))
+
+    // dropdown menu should open
+    await waitFor(() => {
+      expect(container.querySelector('ul.dropdown-menu.show')).toBeInTheDocument();
+    });
+  });
+
+  it('selected item is removed temporarily from dropdown menu and added back when unselected', async () => {
+    const { container } = render(<Combobox menuList={menuList} mode='multi' />);
+
+    fireEvent.click(container.querySelector('div.form-control')!);
+    await waitFor(() => {
+      expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
+    });
+
+    // Selecting an item
+    fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+      ).toBeInTheDocument();
+    });
+
+    // Expect selected item to be removed from dropdown menu
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Afghanistan' })).not.toBeInTheDocument();
+    });
+
+    // Unselecting the item
+    fireEvent.click(screen.getByLabelText('Remove Afghanistan', { selector: 'button' }))
+
+    // Expect selected item to be added back to the dropdown menu
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Afghanistan' })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Multi-select Combobox keyboard behavior', () => {
+  it('previously-selected item is removed when input is empty and "backspace" key is pressed', async () => {
+    const { container } = render(<Combobox menuList={menuList} mode='multi' />);
+
+    fireEvent.click(container.querySelector('div.form-control')!);
+    await waitFor(() => {
+      expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
+    });
+
+    // Selecting an item
+    fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+      ).toBeInTheDocument();
+    });
+
+    // Expect previously-selected item to be removed
+    await waitFor(() => expect(container.querySelector('input')?.value).toBe(''));
+    fireEvent.keyDown(container.querySelector('input')!, { key: 'Backspace', code: 'Backspace' });
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Combobox event handlers', () => {
+  it('onChangeInput fires when input changes', async () => {
+    const mockFn = jest.fn();
+    const { container } = render(
+      <Combobox menuList={menuList} onChangeInput={mockFn} />
+    );
+    fireEvent.change(container.querySelector('input')!, { target: { value: 's' } });
+    await waitFor(() => expect(mockFn).toBeCalledTimes(1));
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'si' } });
+    await waitFor(() => expect(mockFn).toBeCalledTimes(2));
+  });
+
+  it('onChangeInput returns the correct "val" when input value changes', async () => {
+    const mockFn = jest.fn((val, _) => val);
+    const { container } = render(<Combobox menuList={menuList} onChangeInput={mockFn} />);
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'a' } });
+    await waitFor(() => expect(mockFn.mock.calls[0][0]).toBe('a'));
+  });
+
+  it('onChangeSelect fires when an item is selected and unselected',
+    async () => {
+      const mockFn = jest.fn();
+      const { container } = render(<Combobox menuList={menuList} mode='multi' onChangeSelect={mockFn} />);
+
+      fireEvent.click(container.querySelector('div.form-control')!);
+      await waitFor(() => {
+        expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
+      });
+
+      // Selecting an item
+      fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+      await waitFor(() => expect(mockFn).toBeCalledTimes(1));
+
+      // Unselecting an item
+      await waitFor(() => {
+        expect(
+          screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+        ).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByLabelText('Remove Afghanistan', { selector: 'button' }))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+        ).not.toBeInTheDocument();
+      });
+      await waitFor(() => expect(mockFn).toBeCalledTimes(2));
+    });
+
+  it('onChangeSelect called on single-select combobox and returns the correct selected "item" and "items"',
+    async () => {
+      const mockFn = jest.fn((item, items, _) => { item; items; });
+      const { container } = render(<Combobox menuList={menuList} onChangeSelect={mockFn} />);
+
+      fireEvent.click(container.querySelector('div.form-control')!);
+      await waitFor(() => {
+        expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
+      });
+
+      // First item selected
+      fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+      await waitFor(() => expect(mockFn.mock.calls[0][0]).toBe('Afghanistan'));
+      await waitFor(() => expect(mockFn.mock.calls[0][1]).toEqual(['Afghanistan']));
+
+      // Another item selected
+      fireEvent.change(container.querySelector('input')!, { target: { value: '' } });
+      await waitFor(() => expect(container.querySelector('input')?.value).toBe(''));
+      fireEvent.click(screen.getByRole('button', { name: 'Albania' }))
+      await waitFor(() => expect(mockFn.mock.calls[1][0]).toBe('Albania'));
+      await waitFor(() => expect(mockFn.mock.calls[1][1]).toEqual(['Albania']));
+    });
+
+  it('onChangeSelect called on multi-select combobox and returns the correct selected/unselected "item" and selected "items"',
+    async () => {
+      const mockFn = jest.fn((item, items, _) => { item; items; });
+      const { container } = render(<Combobox menuList={menuList} mode='multi' onChangeSelect={mockFn} />);
+
+      fireEvent.click(container.querySelector('div.form-control')!);
+      await waitFor(() => {
+        expect(container.querySelector('ul.dropdown-menu')).toBeInTheDocument();
+      });
+
+      // First item selected
+      fireEvent.click(screen.getByRole('button', { name: 'Afghanistan' }))
+      await waitFor(() => expect(mockFn.mock.calls[0][0]).toBe('Afghanistan'));
+      await waitFor(() => expect(mockFn.mock.calls[0][1]).toEqual(['Afghanistan']));
+
+      // Another item selected
+      fireEvent.click(screen.getByRole('button', { name: 'Albania' }))
+      await waitFor(() => expect(mockFn.mock.calls[1][0]).toBe('Albania'));
+      await waitFor(() => expect(mockFn.mock.calls[1][1]).toEqual(['Afghanistan', 'Albania']));
+
+      // Unselect an item
+      fireEvent.click(screen.getByLabelText('Remove Afghanistan', { selector: 'button' }))
+      await waitFor(() => {
+        expect(
+          screen.queryByLabelText('Remove Afghanistan', { selector: 'button' })
+        ).not.toBeInTheDocument();
+      });
+      await waitFor(() => expect(mockFn.mock.calls[2][0]).toBe('Afghanistan'));
+      await waitFor(() => expect(mockFn.mock.calls[2][1]).toEqual(['Albania']));
+    });
 });

--- a/tests/Combobox/Combobox.test.tsx
+++ b/tests/Combobox/Combobox.test.tsx
@@ -468,7 +468,7 @@ describe('<Combobox>', () => {
 
     expect(
       container.querySelector(
-        '.dropdown.combobox> i.form-control-icon.bi.bi-search'
+        'i.form-control-icon.bi.bi-search'
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
Add `mode` prop to allow users to switch between single and multi-select.

Behavior of single-select mode remains unchanged.

**Addition of (applicable to both single and multi-select):**
* `onChangeSelect` handler to obtain updates to the item selected.
* remove duplicates in `menuList` prop

Inline styles added to account support both single and multi-select modes on same component. (Inline styles to be replaced with classNames in future when they become available in sgds.sass)

**For multi-select mode,**
* Enable selection of multiple menu items
* `SelectedItem` element (purple box) is displayed on selection of an item
* Selected item removed from dropdown menu and added back when removed from selection
* Enable removal of item selection through 'x' button in `SelectedItem`
* Selection and removal of item will trigger `onChangeSelect` handler to obtain updates to item selected/unselected and updated list of items selected
* export `ComboboxMode` type


## Checklist for **multi-select** combobox behaviour:

### Adding the badge
- [x] When values in the menu are selected, it is reflected as a badge within the combobox's input 
- [x] User can select the menu items by three ways: keyboard, mouse and typing in the input. 
- [x] Keyboard interaction: User navigates to the menu item with arrow keys --> selects it with "Enter" --> badge reflected on combobox 
- [x] Mouse interaction: User clicks on the menu item --> badge reflected on combobox 
- [x] Whenever a menu item is selected and has its badge reflected on the combobox, the menu item is also removed temporarily from the dropdown menu. 

### Removing the badge
**User can remove badge on combobox via two ways:**
- [x] Keyboard: User press backspace right before the badge --> badge is removed
- [x] Mouse: User clicks on the badge --> badge is removed. 
- [x] Whenever a badge is removed on the combobox, its value should be restored in the dropdown menu. 

### Menu behaviour
- [x] When a badge is added, the dropdown menu should ~~close~~ remain open
- [x] The dropdown menu should remain open when user is typing until there is a match and a badge is added 
- [x] When deleting badges, the dropdown menu remains ~~close~~ open
