### PR TITLE
docs: fix broken links to React Bootstrap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ With certain SGDS React components, you may want to modify the component or HTML
 
 If you want to keep all the styling of a particular component but switch the component that is finally rendered (whether it's a different SGDS React component, a different custom component, or a different HTML tag), you can use the "as" Prop to do so.
 
-See [example](https://react-bootstrap.github.io/getting-started/introduction#as-prop-api)
+See [example](https://react-bootstrap.github.io/docs/getting-started/introduction#as-prop-api)

--- a/stories/Accordion/Accordion.stories.mdx
+++ b/stories/Accordion/Accordion.stories.mdx
@@ -19,7 +19,7 @@ import AccordionBody from '../../src/Accordion/AccordionBody';
 
 Build vertically collapsing accordions in combination with the Collapse component.
 
-As our components are built on top of `React-Bootstrap` library, do check out the detailed `Accordion` API references <a href="https://react-bootstrap.github.io/components/accordion/" target="_blank">here</a>.
+As our components are built on top of `React-Bootstrap` library, do check out the detailed `Accordion` API references <a href="https://react-bootstrap.github.io/docs/components/accordion/" target="_blank">here</a>.
 
 ## Basic Accordion
 

--- a/stories/Breadcrumb/Breadcrumb.stories.mdx
+++ b/stories/Breadcrumb/Breadcrumb.stories.mdx
@@ -39,7 +39,7 @@ import { Breadcrumb } from '@govtechsg/sgds-react/Breadcrumb';
 
 <ArgsTable story="Default" />
 
-Please refer to https://react-bootstrap.github.io/components/breadcrumb/ for more detailed API documentation on `<Breadcrumb />` and `<Breadcrumb.Item />`
+Please refer to https://react-bootstrap.github.io/docs/components/breadcrumb/ for more detailed API documentation on `<Breadcrumb />` and `<Breadcrumb.Item />`
 
 ## listProps
 

--- a/stories/Card/Card.stories.mdx
+++ b/stories/Card/Card.stories.mdx
@@ -70,7 +70,7 @@ import { Card } from '@govtechsg/sgds-react/Card';
 <ArgsTable story="Base Card" />
 
 SGDS `Card` component is build on top of React-bootstrap.
-Please refer to https://react-bootstrap.github.io/components/cards/#api for more detailed API documentation
+Please refer to https://react-bootstrap.github.io/docs/components/cards/#api for more detailed API documentation
 
 ## Default Card with Call To Action (CTA)
 

--- a/stories/Dropdown/Dropdown.stories.mdx
+++ b/stories/Dropdown/Dropdown.stories.mdx
@@ -30,7 +30,7 @@ import { useState } from 'react';
 
 Toggle contextual overlays for displaying lists of links.
 
-As our components are built on top of `React-Bootstrap` library, do check out the detailed `Dropdown` API references <a href="https:react-bootstrap.github.io/components/dropdowns/" target="_blank">here</a>.
+As our components are built on top of `React-Bootstrap` library, do check out the detailed `Dropdown` API references <a href="https://react-bootstrap.github.io/docs/components/dropdowns/" target="_blank">here</a>.
 
 export const Template = (args) => (
   <Dropdown {...args}>

--- a/stories/Form/Form Input Validations/Validations.stories.mdx
+++ b/stories/Form/Form Input Validations/Validations.stories.mdx
@@ -255,7 +255,7 @@ export const FormikValidation = () => {
 
 Provide valuable, actionable feedback to your users with HTML5 form validation, via browser default behaviors or custom styles and JavaScript.
 
-As our components are built on top of `React-Bootstrap` library, do check out the detailed `Form` API references <a href="https://react-bootstrap.github.io/forms/overview/" target="_blank">here</a>.
+As our components are built on top of `React-Bootstrap` library, do check out the detailed `Form` API references <a href="https://react-bootstrap.github.io/docs/forms/overview/" target="_blank">here</a>.
 
 ## Native HTML5 Form Validation
 

--- a/stories/Form/Form.stories.mdx
+++ b/stories/Form/Form.stories.mdx
@@ -117,7 +117,7 @@ import { Form } from '@govtechsg/sgds-react/Form';
 
 <ArgsTable story="Basic" />
 
-For more detailed API documentation on `Form`, reference <a href="https://react-bootstrap.github.io/forms/overview/" target="_blank">here</a>.
+For more detailed API documentation on `Form`, reference <a href="https://react-bootstrap.github.io/docs/forms/overview/" target="_blank">here</a>.
 
 ## Disabled forms
 

--- a/stories/Form/InputGroup/InputGroup.stories.mdx
+++ b/stories/Form/InputGroup/InputGroup.stories.mdx
@@ -32,7 +32,7 @@
 
 // Easily extend `<Form.Control>` by adding text, buttons, or button groups on either side of textual inputs and custom select. Remember to place `<label>` outside the input group.
 
-// As our components are built on top of `React-Bootstrap` library, do check out the detailed `Form` API references <a href="https://react-bootstrap.github.io/forms/overview/" target="_blank">here</a>.
+// As our components are built on top of `React-Bootstrap` library, do check out the detailed `Form` API references <a href="https://react-bootstrap.github.io/docs/forms/overview/" target="_blank">here</a>.
 
 // export const Template = (args) => {
 //   return (

--- a/stories/Navigation/Nav.stories.mdx
+++ b/stories/Navigation/Nav.stories.mdx
@@ -489,10 +489,10 @@ import { Nav } from '@govtechsg/sgds-react/Nav';
 
 <ArgsTable story="Default" />
 
-Reference API for [NavItem](https://react-bootstrap.github.io/components/navs/#nav-item-props) ,
-[NavLink](https://react-bootstrap.github.io/components/navs/#nav-link-props)
+Reference API for [NavItem](https://react-bootstrap.github.io/docs/components/navs/#navitem) ,
+[NavLink](https://react-bootstrap.github.io/docs/components/navs/#navlink)
 and
-[NavDropdown](/docs/components-navigation-nav-navdropdown--default-story)
+[NavDropdown](https://react-bootstrap.github.io/docs/components/navs/#navdropdown)
 
 ## On first load
 

--- a/stories/Navigation/Navbar.stories.mdx
+++ b/stories/Navigation/Navbar.stories.mdx
@@ -443,7 +443,7 @@ import { Navbar } from '@govtechsg/sgds-react/Nav';
 
 <ArgsTable story="Default" />
 
-For more detailed API documentation , refer to https://react-bootstrap.github.io/components/navbar/#navbar-props
+For more detailed API documentation , refer to https://react-bootstrap.github.io/docs/components/navbar#navbar
 
 ## Collapsible
 

--- a/stories/Tabs/Tabs.stories.mdx
+++ b/stories/Tabs/Tabs.stories.mdx
@@ -268,7 +268,7 @@ import { Tabs } from '@govtechsg/sgds-react/Tabs';
 
 <ArgsTable story="Default" />
 
-As our components are built on top of `React-Bootstrap` library, do check out the detailed `Tabs` API references <a href="https://react-bootstrap.github.io/components/tabs/" target="_blank">here</a>.
+As our components are built on top of `React-Bootstrap` library, do check out the detailed `Tabs` API references <a href="https://react-bootstrap.github.io/docs/components/tabs/" target="_blank">here</a>.
 
 ## Variants
 

--- a/stories/Toast/Toast.stories.mdx
+++ b/stories/Toast/Toast.stories.mdx
@@ -50,7 +50,7 @@ import { Toast } from '@govtechsg/sgds-react/Toast';
 
 <ArgsTable story="Default" />
 
-For more details, refer to https://react-bootstrap.github.io/components/toasts/#toast-props
+For more details, refer to https://react-bootstrap.github.io/docs/components/toasts#toast
 
 #### Code Sample
 

--- a/stories/Tooltip/Tooltip.stories.mdx
+++ b/stories/Tooltip/Tooltip.stories.mdx
@@ -54,7 +54,7 @@ import { Tooltip } from '@govtechsg/sgds-react/Tooltip';
 SGDS `Tooltip` component is built on top of React-bootstrap. Hoverable `Tooltip` uses `OverlayTrigger` component and clickable `Tooltip` uses `Overlay` component.
 The underlying third-party library is Popper.js.
 
-Please refer to https://react-bootstrap.github.io/components/overlays/#api for more detailed API documentation
+Please refer to https://react-bootstrap.github.io/docs/components/overlays#api for more detailed API documentation
 
 ## Target Element / Component
 


### PR DESCRIPTION
All links from the storybook to React Bootstrap API docs are broken due to a path change (and some anchor changes), replace them with currently working links.