### PR TITLE
Kill cypress child processes upon exit

### DIFF
--- a/cypress/scripts/run_all.js
+++ b/cypress/scripts/run_all.js
@@ -1,20 +1,32 @@
-const { exec } = require("child_process");
+const { spawn } = require("child_process");
 
 console.log("\x1b[36m%s\x1b[0m", "Opening React, Next.js apps");
 
-exec(`sh ${__dirname}/run_cra.sh`, (error, stdout, stderr) => {
-    if (error) {
-        console.error("\x1b[31m%s\x1b[0m", "Error from React app");
-        console.error(error.message);
-        return;
-    }
-    console.log(stdout);
-})
-exec(`sh ${__dirname}/run_next.sh`, (error, stdout, stderr) => {
-    if (error) {
-        console.error("\x1b[31m%s\x1b[0m", "Error from Next.js app");
-        console.error(error.message);
-        return;
-    }
-    console.log(stdout);
-})
+// Function to run a shell command and return the child process
+function runCommand(command, name) {
+  const childProcess = spawn(command, { shell: true });
+
+  childProcess.stdout.on("data", data => {
+    console.log("\x1b[32m%s\x1b[0m", `Stdout from ${name} app: ${data}`);
+  });
+
+  childProcess.stderr.on("data", data => {
+    console.error("\x1b[31m%s\x1b[0m", `Stderr from ${name} app: ${data}`);
+  });
+
+  childProcess.on("error", error => {
+    console.error("\x1b[31m%s\x1b[0m", `Error from ${name} app: ${error.message}`);
+  });
+
+  return childProcess;
+}
+
+// Run the commands and store the child processes
+const reactProcess = runCommand(`sh ${__dirname}/run_cra.sh`, "React");
+const nextProcess = runCommand(`sh ${__dirname}/run_next.sh`, "Next.js");
+
+// Terminate all child processes when the main process exits
+process.on("exit", () => {
+  reactProcess.kill();
+  nextProcess.kill();
+});


### PR DESCRIPTION
Previously, the child processes that are spawning the react and next.js apps do not exit upon termination of parent process.

When parent process exits, child processes still continue running. As a result, the ports running those apps are not closed.

This PR fixes this issue.