### PR TITLE
build(esm, cjs modules): add 'use-client' directive for esm and cjs m…

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,7 +11,7 @@ export const parameters = {
   // },
   options: {
     storySort: {
-      order: ['Install', 'Components'],
+      order: ['Install', 'Usage', 'Components'],
     },
   },
 };

--- a/cypress/apps/next-app/app/page.tsx
+++ b/cypress/apps/next-app/app/page.tsx
@@ -1,6 +1,5 @@
-"use client"
-import type { NextPage } from "next";
-import styles from "../styles/Home.module.css";
+import type { NextPage } from 'next';
+import styles from '../styles/Home.module.css';
 import {
   AccordionCom,
   AlertCom,
@@ -24,11 +23,10 @@ import {
   TableCom,
   TabsCom,
   ToastCom,
-  TooltipCom
-} from "@/components";
+  TooltipCom,
+} from '@/components';
 
 const Home: NextPage = () => {
-
   return (
     <div className={styles.container}>
       <NavCom />

--- a/cypress/apps/next-app/components/AccordionCom.tsx
+++ b/cypress/apps/next-app/components/AccordionCom.tsx
@@ -1,23 +1,22 @@
-import { Accordion } from '@govtechsg/sgds-react/Accordion'
-
+import { Accordion, AccordionItem, AccordionHeader, AccordionBody } from '@govtechsg/sgds-react'
 const AccordionCom = () => (
   <Accordion defaultActiveKey="0">
-    <Accordion.Item eventKey="0">
-      <Accordion.Header>
+    <AccordionItem eventKey="0">
+      <AccordionHeader>
         Accordion Item #1
-      </Accordion.Header>
-      <Accordion.Body>
+      </AccordionHeader>
+      <AccordionBody>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </Accordion.Body>
-    </Accordion.Item>
-    <Accordion.Item eventKey="1">
-      <Accordion.Header>
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem eventKey="1">
+      <AccordionHeader>
         Accordion Item #2
-      </Accordion.Header>
-      <Accordion.Body>
+      </AccordionHeader>
+      <AccordionBody>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </Accordion.Body>
-    </Accordion.Item>
+      </AccordionBody>
+    </AccordionItem>
   </Accordion>
 )
 

--- a/cypress/apps/next-app/components/AlertCom.tsx
+++ b/cypress/apps/next-app/components/AlertCom.tsx
@@ -1,4 +1,4 @@
-import { Alert } from "@govtechsg/sgds-react"
+import { Alert, AlertLink } from "@govtechsg/sgds-react"
 
 const AlertCom = () => {
     return (
@@ -10,7 +10,7 @@ const AlertCom = () => {
                             <i className="bi bi-exclamation-circle me-4"></i>
                             <div>
                                 This is a {variant} alert with{' '}
-                                <Alert.Link href="#">an example link</Alert.Link>.
+                                <AlertLink href="#">an example link</AlertLink>.
                                 Give it a click if you like.
                             </div>
                         </Alert>)

--- a/cypress/apps/next-app/components/BreadcrumbCom.tsx
+++ b/cypress/apps/next-app/components/BreadcrumbCom.tsx
@@ -1,16 +1,16 @@
-import { Breadcrumb } from "@govtechsg/sgds-react"
+import { Breadcrumb, BreadcrumbItem } from "@govtechsg/sgds-react"
 
 const BreadcrumbCom = () => {
     return <Breadcrumb>
-        <Breadcrumb.Item href="https://www.designsystem.tech.gov.sg/">
+        <BreadcrumbItem href="https://www.designsystem.tech.gov.sg/">
             Home
-        </Breadcrumb.Item>
-        <Breadcrumb.Item href="https://github.com/GovTechSG/@govtechsg/sgds-react/">
+        </BreadcrumbItem>
+        <BreadcrumbItem href="https://github.com/GovTechSG/@govtechsg/sgds-react/">
             Library
-        </Breadcrumb.Item>
-        <Breadcrumb.Item active>
+        </BreadcrumbItem>
+        <BreadcrumbItem active>
             Data
-        </Breadcrumb.Item>
+        </BreadcrumbItem>
     </Breadcrumb>
 }
 

--- a/cypress/apps/next-app/components/CardCom.tsx
+++ b/cypress/apps/next-app/components/CardCom.tsx
@@ -1,24 +1,24 @@
-import { Card } from "@govtechsg/sgds-react"
+import { Card, CardImg, CardTitle, CardBody, CardLink, CardText } from "@govtechsg/sgds-react"
 
 const CardCom = () => {
   return <>
     <Card>
-      <Card.Img
+      <CardImg
         alt="img alternate text goes here"
         src="https://images.unsplash.com/photo-1473093295043-cdd812d0e601?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80"
         variant="top"
       />
-      <Card.Body>
-        <Card.Title>
+      <CardBody>
+        <CardTitle>
           Card Title
-        </Card.Title>
-        <Card.Text>
+        </CardTitle>
+        <CardText>
           Some quick example text to build on the card title and make up the bulk of the card&apos;s content.
-        </Card.Text>
-        <Card.Link href="#">
+        </CardText>
+        <CardLink href="#">
           Go somewhere
-        </Card.Link>
-      </Card.Body>
+        </CardLink>
+      </CardBody>
     </Card>
   </>
 }

--- a/cypress/apps/next-app/components/DropdownCom.tsx
+++ b/cypress/apps/next-app/components/DropdownCom.tsx
@@ -1,18 +1,18 @@
-import { Dropdown } from "@govtechsg/sgds-react";
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from "@govtechsg/sgds-react";
 
 const DropdownCom = () => {
     return (
         <Dropdown>
-            <Dropdown.Toggle>
+            <DropdownToggle>
                 Dropdown Button<i className="bi bi-chevron-down"></i>
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-                <Dropdown.Item href="#">Action</Dropdown.Item>
-                <Dropdown.Item href="#">Another action</Dropdown.Item>
-                <Dropdown.Item>
+            </DropdownToggle>
+            <DropdownMenu>
+                <DropdownItem href="#">Action</DropdownItem>
+                <DropdownItem href="#">Another action</DropdownItem>
+                <DropdownItem>
                     Something else
-                </Dropdown.Item>
-            </Dropdown.Menu>
+                </DropdownItem>
+            </DropdownMenu>
         </Dropdown>
     );
 };

--- a/cypress/apps/next-app/components/FileUploadCom.tsx
+++ b/cypress/apps/next-app/components/FileUploadCom.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { FileUpload } from "@govtechsg/sgds-react"
 import { useState } from "react";
 

--- a/cypress/apps/next-app/components/FooterCom.tsx
+++ b/cypress/apps/next-app/components/FooterCom.tsx
@@ -1,85 +1,95 @@
-import { Footer } from "@govtechsg/sgds-react"
+import {
+  Footer,
+  FooterTop,
+  FooterTopHeader,
+  FooterTopItem,
+  FooterTopItemGroup,
+  FooterTopContactLinks,
+  FooterBottom,
+  FooterBottomLinks,
+  FooterBottomCopyrights
+} from '@govtechsg/sgds-react';
 
 const FooterCom = () => {
-    return (
-        <Footer>
-            <Footer.Top>
-                <Footer.Top.Header headerTitle="Singapore Government Design System">
-                    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Earum illo
-                    delectus laborum libero id ratione quibusdam tempora assumenda quas,
-                    pariatur cum minus, aliquid molestiae et nisi dolorem vitae molestias!
-                    Voluptate commodi aliquid iusto sequi sit eligendi, quod numquam nihil
-                    consectetur eaque error earum laudantium! Temporibus accusamus pariatur
-                    quod totam quia.
-                </Footer.Top.Header>
-                <Footer.Top.ItemGroup>
-                    <Footer.Top.Item itemTitle="Column 1">
-                        <a href="">About Us</a>
-                        <a href="">This is a super long link</a>
-                        <a href="">Test</a>
-                        <a href="">Test</a>
-                    </Footer.Top.Item>
-                    <Footer.Top.Item itemTitle="Column 2">
-                        <a href="">About Us</a>
-                        <a href="">This is a super long link</a>
-                        <a href="">Test</a>
-                        <a href="">Test</a>
-                    </Footer.Top.Item>
-                    <Footer.Top.Item itemTitle="Column 3">
-                        <a href="">About Us</a>
-                        <a href="">This is a super long link</a>
-                        <a href="">Test</a>
-                        <a href="">Test</a>
-                    </Footer.Top.Item>
-                    <Footer.Top.Item itemTitle="Column 4">
-                        <a href="">About Us</a>
-                        <a href="">This is a super long link</a>
-                        <a href="">Test</a>
-                        <a href="">Test</a>
-                    </Footer.Top.Item>
-                    <Footer.Top.Item itemTitle="Column 5">
-                        <a href="">About Us</a>
-                        <a href="">This is a super long link</a>
-                        <a href="">Test</a>
-                        <a href="">Test</a>
-                    </Footer.Top.Item>
-                    <Footer.Top.Item itemTitle="Column 6">
-                        <a href="">About Us</a>
-                        <a href="">This is a super long link</a>
-                        <a href="">Test</a>
-                        <a href="">Test</a>
-                    </Footer.Top.Item>
-                </Footer.Top.ItemGroup>
-                <Footer.Top.ContactLinks>
-                    <a href="">Contact</a>
-                    <a href="">Feedback</a>
-                    <a
-                        href="https://www.reach.gov.sg/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Reach.gov.sg
-                    </a>
-                </Footer.Top.ContactLinks>
-            </Footer.Top>
-            <Footer.Bottom>
-                <Footer.Bottom.Links>
-                    <a
-                        href="https://tech.gov.sg/report_vulnerability"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Report Vulnerability
-                    </a>
-                    <a href="">Privacy</a>
-                    <a href="">Terms of use</a>
-                </Footer.Bottom.Links>
-                <Footer.Bottom.Copyrights>
-                    © 2022 Government of Singapore. Last Updated 08 Feb 2022
-                </Footer.Bottom.Copyrights>
-            </Footer.Bottom>
-        </Footer>
-    )
-}
+  return (
+    <Footer>
+      <FooterTop>
+        <FooterTopHeader headerTitle="Singapore Government Design System">
+          Lorem ipsum, dolor sit amet consectetur adipisicing elit. Earum illo
+          delectus laborum libero id ratione quibusdam tempora assumenda quas,
+          pariatur cum minus, aliquid molestiae et nisi dolorem vitae molestias!
+          Voluptate commodi aliquid iusto sequi sit eligendi, quod numquam nihil
+          consectetur eaque error earum laudantium! Temporibus accusamus
+          pariatur quod totam quia.
+        </FooterTopHeader>
+        <FooterTopItemGroup>
+          <FooterTopItem itemTitle="Column 1">
+            <a href="">About Us</a>
+            <a href="">This is a super long link</a>
+            <a href="">Test</a>
+            <a href="">Test</a>
+          </FooterTopItem>
+          <FooterTopItem itemTitle="Column 2">
+            <a href="">About Us</a>
+            <a href="">This is a super long link</a>
+            <a href="">Test</a>
+            <a href="">Test</a>
+          </FooterTopItem>
+          <FooterTopItem itemTitle="Column 3">
+            <a href="">About Us</a>
+            <a href="">This is a super long link</a>
+            <a href="">Test</a>
+            <a href="">Test</a>
+          </FooterTopItem>
+          <FooterTopItem itemTitle="Column 4">
+            <a href="">About Us</a>
+            <a href="">This is a super long link</a>
+            <a href="">Test</a>
+            <a href="">Test</a>
+          </FooterTopItem>
+          <FooterTopItem itemTitle="Column 5">
+            <a href="">About Us</a>
+            <a href="">This is a super long link</a>
+            <a href="">Test</a>
+            <a href="">Test</a>
+          </FooterTopItem>
+          <FooterTopItem itemTitle="Column 6">
+            <a href="">About Us</a>
+            <a href="">This is a super long link</a>
+            <a href="">Test</a>
+            <a href="">Test</a>
+          </FooterTopItem>
+        </FooterTopItemGroup>
+        <FooterTopContactLinks>
+          <a href="">Contact</a>
+          <a href="">Feedback</a>
+          <a
+            href="https://www.reach.gov.sg/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Reach.gov.sg
+          </a>
+        </FooterTopContactLinks>
+      </FooterTop>
+      <FooterBottom>
+        <FooterBottomLinks>
+          <a
+            href="https://tech.gov.sg/report_vulnerability"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Report Vulnerability
+          </a>
+          <a href="">Privacy</a>
+          <a href="">Terms of use</a>
+        </FooterBottomLinks>
+        <FooterBottomCopyrights>
+          © 2022 Government of Singapore. Last Updated 08 Feb 2022
+        </FooterBottomCopyrights>
+      </FooterBottom>
+    </Footer>
+  );
+};
 
 export default FooterCom;

--- a/cypress/apps/next-app/components/FormCom.tsx
+++ b/cypress/apps/next-app/components/FormCom.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Button, Form } from "@govtechsg/sgds-react";
 import { FormEvent } from "react";
 

--- a/cypress/apps/next-app/components/ModalCom.tsx
+++ b/cypress/apps/next-app/components/ModalCom.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Button, Modal } from "@govtechsg/sgds-react";
 import { useState } from "react";
 

--- a/cypress/apps/next-app/components/NavCom.tsx
+++ b/cypress/apps/next-app/components/NavCom.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Navbar, Nav, Container, Row, Col } from '@govtechsg/sgds-react';
 import { useState } from 'react';
 

--- a/cypress/apps/next-app/components/PaginationCom.tsx
+++ b/cypress/apps/next-app/components/PaginationCom.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Pagination, Table } from '@govtechsg/sgds-react';
 import React, { useState, useEffect } from 'react';
 

--- a/cypress/apps/next-app/components/QuantityToggleCom.tsx
+++ b/cypress/apps/next-app/components/QuantityToggleCom.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { QuantityToggle } from "@govtechsg/sgds-react";
 import { useState } from "react";
 

--- a/cypress/apps/next-app/components/SidenavCom.tsx
+++ b/cypress/apps/next-app/components/SidenavCom.tsx
@@ -1,38 +1,38 @@
-import { SideNav } from "@govtechsg/sgds-react"
+import { SideNav, SideNavItem, SideNavButton, SideNavCollapse, SideNavLink } from "@govtechsg/sgds-react"
 
 const SideNavCom = () => {
     return (
         <SideNav>
-            <SideNav.Item eventKey="0">
-                <SideNav.Button>SideNav Item #1</SideNav.Button>
-                <SideNav.Collapse>
+            <SideNavItem eventKey="0">
+                <SideNavButton>SideNav Item #1</SideNavButton>
+                <SideNavCollapse>
                     <>
-                        <SideNav.Link eventKey="nl-1" href="#">
+                        <SideNavLink eventKey="nl-1" href="#">
                             number one
-                        </SideNav.Link>
-                        <SideNav.Link eventKey="nl-2" href="#">
+                        </SideNavLink>
+                        <SideNavLink eventKey="nl-2" href="#">
                             number one
-                        </SideNav.Link>
-                        <SideNav.Link eventKey="nl-3" href="#">
+                        </SideNavLink>
+                        <SideNavLink eventKey="nl-3" href="#">
                             number one
-                        </SideNav.Link>
+                        </SideNavLink>
                     </>
-                </SideNav.Collapse>
-            </SideNav.Item>
-            <SideNav.Item eventKey="1">
-                <SideNav.Button>SideNav Item #2</SideNav.Button>
-                <SideNav.Collapse>
+                </SideNavCollapse>
+            </SideNavItem>
+            <SideNavItem eventKey="1">
+                <SideNavButton>SideNav Item #2</SideNavButton>
+                <SideNavCollapse>
                     <>
-                        <SideNav.Link eventKey="nl-4">number two</SideNav.Link>
-                        <SideNav.Link eventKey="nl-6">number two</SideNav.Link>
-                        <SideNav.Link eventKey="nl-7">number two</SideNav.Link>
-                        <SideNav.Link eventKey="nl-8">number two</SideNav.Link>
+                        <SideNavLink eventKey="nl-4">number two</SideNavLink>
+                        <SideNavLink eventKey="nl-6">number two</SideNavLink>
+                        <SideNavLink eventKey="nl-7">number two</SideNavLink>
+                        <SideNavLink eventKey="nl-8">number two</SideNavLink>
                     </>
-                </SideNav.Collapse>
-            </SideNav.Item>
-            <SideNav.Item eventKey="2">
-                <SideNav.Button href="#">SideNav Item #3</SideNav.Button>
-            </SideNav.Item>
+                </SideNavCollapse>
+            </SideNavItem>
+            <SideNavItem eventKey="2">
+                <SideNavButton href="#">SideNav Item #3</SideNavButton>
+            </SideNavItem>
         </SideNav>
     )
 }

--- a/cypress/apps/next-app/components/StepperCom.tsx
+++ b/cypress/apps/next-app/components/StepperCom.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Stepper, useStep } from "@govtechsg/sgds-react";
 
 const StepperCom = () => {

--- a/cypress/apps/next-app/components/ToastCom.tsx
+++ b/cypress/apps/next-app/components/ToastCom.tsx
@@ -1,14 +1,12 @@
-import { Toast } from "@govtechsg/sgds-react";
-import { useState } from "react";
+import { Toast, ToastHeader, ToastBody } from "@govtechsg/sgds-react";
 
 const ToastCom = () => {
-    const [show, setShow] = useState(true);
-    return <Toast onClose={() => setShow(false)} show={show}>
-        <Toast.Header>
+    return <Toast show={true}>
+        <ToastHeader>
             <i className="bi bi-check-circle me-2"></i>
             <strong className="me-auto">Title</strong>
-        </Toast.Header>
-        <Toast.Body>This is a toast message.</Toast.Body>
+        </ToastHeader>
+        <ToastBody>This is a toast message.</ToastBody>
     </Toast>
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -83,11 +83,13 @@ export default [
         file: 'dist/index.esm.js',
         exports: 'named',
         format: 'esm',
+        banner: `'use client';`,
       },
       {
         file: 'dist/index.cjs.js',
         exports: 'named',
         format: 'cjs',
+        banner: `'use client';`,
       }
     ],
     plugins: commonPlugins,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,11 +29,13 @@ function component(commonPlugins, folder) {
         file: `dist/${folder}/index.esm.js`,
         exports: 'named',
         format: 'esm',
+        banner: `'use client';`,
       },
       {
         file: `dist/${folder}/index.cjs.js`,
         exports: 'named',
         format: 'cjs',
+        banner: `'use client';`,
       }
     ],
     plugins: [

--- a/src/Accordion/index.ts
+++ b/src/Accordion/index.ts
@@ -10,3 +10,10 @@ export {
   useAccordionButton,
 } from './AccordionButton';
 export type { AccordionButtonProps } from './AccordionButton';
+
+export { default as AccordionItem } from './AccordionItem';
+export type { AccordionItemProps } from './AccordionItem';
+export { default as AccordionHeader } from './AccordionHeader';
+export type { AccordionHeaderProps } from './AccordionHeader';
+export { default as AccordionBody } from './AccordionBody';
+export type { AccordionBodyProps } from './AccordionBody';

--- a/src/Alert/AlertHeading.tsx
+++ b/src/Alert/AlertHeading.tsx
@@ -8,3 +8,4 @@ const DivStyledAsH4 = divWithClassName('h4');
   Component: DivStyledAsH4,
 });
 
+export default AlertHeading;

--- a/src/Alert/AlertLink.tsx
+++ b/src/Alert/AlertLink.tsx
@@ -5,4 +5,5 @@ export const AlertLink = createWithBsPrefix('alert-link', {
   Component: 'a',
 });
 
+export default AlertLink;
 

--- a/src/Alert/index.ts
+++ b/src/Alert/index.ts
@@ -1,3 +1,7 @@
-
 export { default as Alert } from './Alert';
 export type { AlertProps } from './Alert';
+
+export { default as AlertLink } from './AlertLink';
+// export type { AlertLinkProps } from './AlertLink';
+
+export { default as AlertHeading } from './AlertHeading';

--- a/src/Card/index.ts
+++ b/src/Card/index.ts
@@ -1,10 +1,22 @@
 export { default as Card } from './Card';
 export type { CardProps } from './Card';
-export { default as SelectableCard } from './SelectableCard'
-export type { SelectableCardProps } from './SelectableCard'
 
 export { default as CardImg } from './CardImg';
 export type { CardImgProps } from './CardImg';
 
-export { default as CardGroup } from './CardGroup';
+export {
+  CardTitle,
+  CardSubtitle,
+  CardLink,
+  CardStretchedLink,
+  CardText,
+  CardFooter,
+  CardImgOverlay,
+  CardUnit,
+  CardBody,
+} from './CardMisc';
 
+export { default as SelectableCard } from './SelectableCard';
+export type { SelectableCardProps } from './SelectableCard';
+
+export { default as CardGroup } from './CardGroup';

--- a/src/Card/index.ts
+++ b/src/Card/index.ts
@@ -20,3 +20,4 @@ export { default as SelectableCard } from './SelectableCard';
 export type { SelectableCardProps } from './SelectableCard';
 
 export { default as CardGroup } from './CardGroup';
+export { default as CardHeader } from './CardHeader';

--- a/src/Dropdown/index.ts
+++ b/src/Dropdown/index.ts
@@ -4,4 +4,17 @@ export type { DropdownProps } from './Dropdown';
 export { default as DropdownButton } from './DropdownButton';
 export type { DropdownButtonProps } from './DropdownButton';
 
-export type {DropdownMenuProps} from './DropdownMenu'
+export { default as DropdownMenu } from './DropdownMenu';
+export type { DropdownMenuProps } from './DropdownMenu';
+
+export { default as DropdownItem } from './DropdownItem';
+export type { DropdownItemProps } from './DropdownItem';
+
+export { default as DropdownToggle } from './DropdownToggle';
+export type { DropdownToggleProps } from './DropdownToggle';
+
+export {
+  DropdownHeader,
+  DropdownDivider,
+  DropdownItemText,
+} from './DropdownMisc';

--- a/src/FileUpload/FileUpload.tsx
+++ b/src/FileUpload/FileUpload.tsx
@@ -76,25 +76,25 @@ const propTypes = {
 
 const CHECKED_ICON = <i className="bi bi-check-lg check-icon" />;
 const CANCEL_ICON = <i className="bi bi-x-circle x-circle-icon" />;
-const defaultProps = {
-  variant: 'primary',
-  disabled: false,
-  checkedIcon: CHECKED_ICON,
-  cancelIcon: CANCEL_ICON,
-  multiple: false,
-};
+// const defaultProps = {
+//   variant: 'primary',
+//   disabled: false,
+//   checkedIcon: CHECKED_ICON,
+//   cancelIcon: CANCEL_ICON,
+//   multiple: false,
+// };
 
 export const FileUpload: React.FC<FileUploadProps> = ({
   controlId,
-  variant,
+  variant = "primary",
   onChangeFile,
   selectedFile,
-  disabled,
+  disabled = false,
   size,
   children,
   checkedIcon = CHECKED_ICON,
   cancelIcon = CANCEL_ICON,
-  multiple,
+  multiple = false,
   accept,
   buttonClassName
 }) => {
@@ -184,4 +184,4 @@ export const FileUpload: React.FC<FileUploadProps> = ({
 
 FileUpload.displayName = 'FileUpload';
 FileUpload.propTypes = propTypes;
-FileUpload.defaultProps = defaultProps;
+// FileUpload.defaultProps = defaultProps;

--- a/src/Form/Switch.tsx
+++ b/src/Form/Switch.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import FormCheck, { FormCheckProps } from './FormCheck';
 import { BsPrefixRefForwardingComponent } from '../utils/helpers';
 
-type SwitchProps = Omit<FormCheckProps, 'type'>;
+export type SwitchProps = Omit<FormCheckProps, 'type'>;
 
 const Switch: BsPrefixRefForwardingComponent<typeof FormCheck, SwitchProps> =
   React.forwardRef<typeof FormCheck, SwitchProps>((props, ref) => (

--- a/src/Form/index.ts
+++ b/src/Form/index.ts
@@ -10,6 +10,12 @@ export type { FormControlGroupProps } from './FormControlGroup';
 export { default as FormCheck } from './FormCheck';
 export type { FormCheckProps } from './FormCheck';
 
+export { default as FormCheckInput } from './FormCheckInput';
+export type { FormCheckInputProps } from './FormCheckInput';
+
+export { default as FormCheckLabel } from './FormCheckLabel';
+export type { FormCheckLabelProps } from './FormCheckLabel';
+
 export { default as FormGroup } from './FormGroup';
 export type { FormGroupProps } from './FormGroup';
 

--- a/src/Form/index.ts
+++ b/src/Form/index.ts
@@ -24,3 +24,6 @@ export type { FormSelectProps } from './FormSelect';
 
 export { default as Feedback } from './Feedback'
 export type { FeedbackProps } from './Feedback';
+
+export { default as FormSwitch } from './Switch';
+export type { SwitchProps } from './Switch'

--- a/src/InputGroup/index.ts
+++ b/src/InputGroup/index.ts
@@ -1,2 +1,5 @@
 export { default as InputGroup } from './InputGroup';
 export type { InputGroupProps } from './InputGroup';
+
+export { InputGroupRadio, InputGroupCheckbox } from './InputGroupMisc';
+export { InputGroupText } from './InputGroupText';

--- a/src/Modal/index.ts
+++ b/src/Modal/index.ts
@@ -2,8 +2,11 @@ export { default as Modal } from './Modal';
 export type { ModalProps } from './Modal';
 
 export { default as ModalBody } from './ModalBody';
+
 export { default as ModalDialog } from './ModalDialog';
 export type { ModalDialogProps } from './ModalDialog';
 
 export { default as ModalFooter } from './ModalFooter';
 export { default as ModalTitle } from './ModalTitle';
+export { default as ModalHeader } from './ModalHeader';
+export type { ModalHeaderProps } from './ModalHeader';

--- a/src/Nav/index.ts
+++ b/src/Nav/index.ts
@@ -14,3 +14,11 @@ export type { NavbarProps } from './Navbar';
 
 export { default as NavbarBrand } from './NavbarBrand';
 export type { NavbarBrandProps } from './NavbarBrand';
+
+export { default as NavbarCollapse } from './NavbarCollapse';
+export type { NavbarCollapseProps } from './NavbarCollapse';
+
+export {  NavbarText } from './NavbarText';
+
+export { default as NavbarToggle } from './NavbarToggle';
+export type { NavbarToggleProps } from './NavbarToggle';

--- a/src/SideNav/index.ts
+++ b/src/SideNav/index.ts
@@ -1,3 +1,14 @@
 export { default as SideNav } from './SideNav';
 export type { SideNavProps } from './SideNav';
+
 export { default as SideNavButton } from './SideNavButton';
+export type { SideNavButtonProps } from './SideNavButton';
+
+export { default as SideNavCollapse } from './SideNavCollapse';
+export type { SideNavCollapseProps } from './SideNavCollapse';
+
+export { default as SideNavItem } from './SideNavItem';
+export type { SideNavItemProps } from './SideNavItem';
+
+export { default as SideNavLink } from './SideNavLink';
+export type { SideNavLinkProps } from './SideNavLink'

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -2,4 +2,12 @@ export { default as Tabs } from './Tabs';
 export type { TabsProps } from './Tabs';
 
 export { default as Tab } from './Tab';
-export type { TabProps } from './Tab'
+export type { TabProps } from './Tab';
+
+export { default as TabContainer } from './TabContainer';
+export type { TabContainerProps } from './TabContainer';
+
+export { default as TabContent } from './TabContent';
+
+export { default as TabPane } from './TabPane';
+export type { TabPaneProps } from './TabPane';

--- a/stories/installation.stories.mdx
+++ b/stories/installation.stories.mdx
@@ -4,3 +4,4 @@ import Readme from '/README.md';
 <Meta title="Install" />
 
 <Description markdown={Readme} />
+ 

--- a/stories/usage/jest.md
+++ b/stories/usage/jest.md
@@ -1,0 +1,25 @@
+# Usage with Jest 
+
+Jest support for ESM modules is still experimental. Configure jest to transpile the package like so
+
+## `jest.config.js`
+
+```js
+...
+transformIgnorePatterns: [
+    "/node_modules/(?!(@govtechsg/sgds-react)/)",
+  ]
+```
+
+## `next/js`
+
+```js
+async function jestConfig() {
+  const nextJestConfig = await createJestConfig(customJestConfig)()
+  // /node_modules/ is the first pattern
+  nextJestConfig.transformIgnorePatterns[0] = '/node_modules/(?!uuid)/'
+  return nextJestConfig
+}
+
+module.exports = jestConfig
+```

--- a/stories/usage/jest.stories.mdx
+++ b/stories/usage/jest.stories.mdx
@@ -1,0 +1,6 @@
+import { Meta, Description } from '@storybook/addon-docs';
+import Jest from './jest.md';
+
+<Meta title="Usage/Jest" />
+
+<Description markdown={Jest} />

--- a/stories/usage/nextjs.md
+++ b/stories/usage/nextjs.md
@@ -1,0 +1,50 @@
+# Usage with Next.js
+
+## "use client" directive
+
+Our components are client side components and will require the "use client" directive in Next.js
+
+For versions before 2.3.0 , add "use client" in files where you import our components
+
+```jsx
+'use client';
+import { Alert } from '@govtechsg/sgds-react';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Alert key={idx} variant={variant} className="d-flex align-items-center">
+    <i className="bi bi-exclamation-circle me-4"></i>
+    <div>
+      This is a {variant} alert with
+      <Alert.Link href="#">an example link</Alert.Link>. Give it a click if you
+      like.
+    </div>
+  </Alert>
+);
+
+export default App;
+```
+
+Since version 2.3+ , "use client" directive are incorporated in the components itself. Hence, you do not need to add the "use client" directive when importing the components. 
+
+```jsx
+import { Alert, AlertLink } from '@govtechsg/sgds-react';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Alert key={idx} variant={variant} className="d-flex align-items-center">
+    <i className="bi bi-exclamation-circle me-4"></i>
+    <div>
+      This is a {variant} alert with
+      <AlertLink href="#">an example link</AlertLink>. Give it a click if you
+      like.
+    </div>
+  </Alert>
+);
+
+export default App;
+```
+
+**Note** Notice the example above imports and uses `AlertLink` instead of `Alert.Link`. Due to an [upstream issue from Next.js](https://github.com/vercel/next.js/issues/51593), you cannot use sub components like `Alert.Link` as with the first example where "use client" directive was used. If you use it, you will face an error:
+
+`Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.` 

--- a/stories/usage/nextjs.stories.mdx
+++ b/stories/usage/nextjs.stories.mdx
@@ -1,0 +1,6 @@
+import { Meta, Description } from '@storybook/addon-docs';
+import NextJs from './nextjs.md';
+
+<Meta title="Usage/Next.js" />
+
+<Description markdown={NextJs} />


### PR DESCRIPTION
**Ticket SGDS-668**

React components are client side components as it uses hook (useContext and in future useId). 

Users of nextjs will have to add "use client" whenever they use our components and it becomes a hassle as they have create a file and wrap our components with 'use client'.  This is ok for big components that they need to customize and wrap over, but for smaller components like button which they expect to use out of the hood , its quite a hassle. 

Client side react users are unaffected, and should be unaffected by this update. 

**Solution found at https://www.misha.wtf/blog/rollup-server-components**

Tested on cypress e2e apps to be working.
