### PR TITLE
fix(*): remove default props [skip-cd]

### DIFF
--- a/src/Card/SelectableCard.tsx
+++ b/src/Card/SelectableCard.tsx
@@ -50,19 +50,17 @@ const propTypes = {
   border: PropTypes.string,
 
   /** Category title of the Card */
-  categoryTitle: PropTypes.node
+  categoryTitle: PropTypes.node,
 };
 
-const defaultProps: Partial<SelectableCardProps> = {
-  disabled: false,
-  type: 'checkbox',
-};
 const SelectableCard: React.FC<SelectableCardProps> = ({
   children,
   bg,
   text,
   border,
   categoryTitle,
+  disabled = false,
+  type = 'checkbox',
   ...props
 }) => {
   const formCheckRef = React.useRef<HTMLInputElement>(null);
@@ -78,23 +76,19 @@ const SelectableCard: React.FC<SelectableCardProps> = ({
       onClick={handleSelect}
       tabIndex={0}
       variant="card-action"
-      className={
-        props.checked && !props.disabled
-          ? 'is-active'
-          : undefined
-      }
+      className={props.checked && !disabled ? 'is-active' : undefined}
       {...cardProps}
     >
       <Card.Body>
-      <Card.Subtitle as="h6" className="text-muted">
-        <div>{categoryTitle}</div>
-        <div className="card-input">
-        <FormCheck
-            ref={formCheckRef}
-            {...formCheckProps}
-            onClick={handleSelect}
-          ></FormCheck>
-        </div>
+        <Card.Subtitle as="h6" className="text-muted">
+          <div>{categoryTitle}</div>
+          <div className="card-input">
+            <FormCheck
+              ref={formCheckRef}
+              {...formCheckProps}
+              onClick={handleSelect}
+            ></FormCheck>
+          </div>
         </Card.Subtitle>
         {children}
       </Card.Body>
@@ -103,6 +97,5 @@ const SelectableCard: React.FC<SelectableCardProps> = ({
 };
 
 SelectableCard.displayName = 'SelectableCard';
-SelectableCard.defaultProps = defaultProps;
 SelectableCard.propTypes = propTypes as any;
 export default SelectableCard;

--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -9,7 +9,6 @@ import useMergedRefs from '@restart/hooks/useMergedRefs';
 import Overlay, { OverlayChildren, OverlayProps } from './Overlay';
 import safeFindDOMNode from '../utils/safeFindDOMNode';
 
-
 export type OverlayTriggerType = 'hover' | 'click' | 'focus';
 
 export type OverlayDelay = number | { show: number; hide: number };
@@ -60,7 +59,9 @@ interface INativeEvent extends MouseEvent {
 // moving from one child element to another.
 function handleMouseOverOut(
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  handler: (...args: [React.MouseEvent<Element, INativeEvent>, ...any[]]) => any,
+  handler: (
+    ...args: [React.MouseEvent<Element, INativeEvent>, ...any[]]
+  ) => any,
   args: [React.MouseEvent<Element, INativeEvent>, ...any[]],
   relatedNative: RelatedNative
 ) {
@@ -168,13 +169,8 @@ const propTypes = {
   ]),
 };
 
-const defaultProps = {
-  defaultShow: false,
-  trigger: ['hover', 'focus'],
-};
-
 function OverlayTrigger({
-  trigger,
+  trigger = ['hover', 'focus'],
   overlay,
   children,
   popperConfig = {},
@@ -318,7 +314,6 @@ function OverlayTrigger({
   );
 }
 
-OverlayTrigger.defaultProps = defaultProps;
 OverlayTrigger.propTypes = propTypes;
 
 export default OverlayTrigger;

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -99,12 +99,6 @@ const propTypes = {
   unmountOnExit: PropTypes.bool,
 };
 
-const defaultProps = {
-  // variant: 'tabs',
-  mountOnEnter: false,
-  unmountOnExit: false,
-};
-
 function getDefaultActiveKey(children: React.ReactChildren) {
   let defaultActiveKey: undefined;
   forEach(children, (child) => {
@@ -166,14 +160,16 @@ function renderTab(variant?: TabsVariant) {
   };
 }
 
-const Tabs = (props: TabsProps) => {
+const Tabs = ({
+  mountOnEnter = false,
+  unmountOnExit = false,
+  ...props
+}: TabsProps) => {
   const {
     id,
     variant,
     onSelect,
     transition,
-    mountOnEnter,
-    unmountOnExit,
     children,
     activeKey = getDefaultActiveKey(children as React.ReactChildren),
     ...controlledProps
@@ -210,7 +206,6 @@ const Tabs = (props: TabsProps) => {
 };
 
 Tabs.propTypes = propTypes;
-Tabs.defaultProps = defaultProps;
 Tabs.displayName = 'Tabs';
 
 export default Tabs;

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -15,7 +15,7 @@ export interface TooltipProps {
   type?: 'hover' | 'click';
   /** The content to be displayed in the tooltip */
   content: string;
-  children?: React.ReactNode
+  children?: React.ReactNode;
 }
 const propTypes = {
   placement: PropTypes.oneOf<TooltipPlacement>([
@@ -30,21 +30,21 @@ const propTypes = {
   content: PropTypes.oneOfType([PropTypes.string]),
   children: PropTypes.element,
 };
-const defaultProps: TooltipProps = {
-  placement: 'top',
-  type: 'hover',
-  content: '',
-};
 
-export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps) => {
-  const { type, placement, content, children } = props;
+export const Tooltip: React.FC<TooltipProps> = ({
+  placement = 'top',
+  type = 'hover',
+  content = '',
+  children,
+  ...props
+}) => {
   const [show, setShow] = useState(false);
   const target = useRef(null);
-  
-  const [tooltipId, setTooltipId] = useState("")
+
+  const [tooltipId, setTooltipId] = useState('');
   React.useEffect(() => {
     setTooltipId(generateId('tooltip', 'div'));
-  }, [])
+  }, []);
 
   const clickToolTip = () => (
     <>
@@ -72,7 +72,11 @@ export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps) => {
   const hoverTooltip = () => (
     <OverlayTrigger
       placement={placement}
-      overlay={<TooltipBox id={tooltipId} {...props}>{content}</TooltipBox>}
+      overlay={
+        <TooltipBox id={tooltipId} {...props}>
+          {content}
+        </TooltipBox>
+      }
     >
       {React.cloneElement(children as React.ReactElement, {
         onClick: () => setShow(!show),
@@ -82,8 +86,7 @@ export const Tooltip: React.FC<TooltipProps> = ((props = defaultProps) => {
     </OverlayTrigger>
   );
   return type === 'hover' ? hoverTooltip() : clickToolTip();
-})
+};
 
-Tooltip.defaultProps = defaultProps;
 Tooltip.propTypes = propTypes as any;
 export default Tooltip;


### PR DESCRIPTION
## Description
This pull request is to remove Default Props of `SelectableCard`, `Tooltip`, `Tabs` and `OverlayTrigger` components as Default Props has been deprecated for Functional Components.

## Fixes
1. remove defaultProps property of the component.
2. add default value of the props to the function argument.