### PR TITLE
fix(badge): storybook args table name [skip-cd]

### DIFF
--- a/stories/Badge/Badge.stories.mdx
+++ b/stories/Badge/Badge.stories.mdx
@@ -71,10 +71,10 @@ export const Template = (args) => {
 ## API
 
 ```jsx
-import { Badge } from '@govtechsg/sgds-react/Badge'; 
+import { Badge } from '@govtechsg/sgds-react/Badge';
 ```
 
-<ArgsTable story="Badge" />
+<ArgsTable story="Basic" />
 
 ## Contextual variations
 
@@ -145,10 +145,7 @@ export const ComponentBadgeTemplate = (args) => (
 Badge can also be used on other components as a dot indicator or text indicator for notification or alerts.
 
 <Canvas>
-  <Story
-    name="dot indicator"
-    args={{ dotIndicator: true, bg: 'danger' }}
-  >
+  <Story name="dot indicator" args={{ dotIndicator: true, bg: 'danger' }}>
     {ComponentBadgeTemplate.bind({})}
   </Story>
   <Story


### PR DESCRIPTION
## Description
This pull request is to fix the missing args table of `Badge` component on storybook.

## Fixes
1. rename the correct name of `ArgsTable`