### PR TITLE
A11y/datepicker [skip-cd]

### DIFF
--- a/src/DatePicker/Calendar.tsx
+++ b/src/DatePicker/Calendar.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import DatePickerContext from './DatePickerContext';
 import { RangeSelectionValue, getTotalDaysInMonth } from './DatePicker';
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 
+dayjs.extend(localizedFormat);
 interface CalendarProps extends React.HTMLAttributes<HTMLTableElement> {
   selectedDate: Date | RangeSelectionValue | undefined;
   displayDate: Date;
@@ -145,8 +148,11 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
       for (let j = 0; j <= 6; j++) {
         if (day <= monthLength && (i > 0 || j >= startingDay)) {
           let className = undefined;
+          let ariaSelected = false;
           const dayIndex = day;
           const date = new Date(year, month, day, 12, 0, 0, 0);
+          const localizedDate = dayjs(date).format('dddd, MMMM D, YYYY');
+
           const dateString = date.toISOString();
           const beforeMinDate =
             minimumDate &&
@@ -175,6 +181,7 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
             processedSelectedDate &&
             isSelectedDate(date, processedSelectedDate)
           ) {
+            ariaSelected = true;
             if (processedSelectedDate instanceof Date) {
               className = 'bg-primary-600 text-white';
             } else {
@@ -204,6 +211,8 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
           week.push(
             <td
               key={j}
+              aria-label={localizedDate}
+              aria-selected={ariaSelected}
               data-day={day}
               onClick={clickHandler}
               style={style}
@@ -343,7 +352,6 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
         className="text-center"
         role="grid"
         ref={ref}
-        aria-labelledby="id-grid-label"
         onKeyDown={handleKeyDown} // Attach the keydown event listener to the table
       >
         <thead>

--- a/src/DatePicker/Calendar.tsx
+++ b/src/DatePicker/Calendar.tsx
@@ -147,8 +147,8 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
       const week = [];
       for (let j = 0; j <= 6; j++) {
         if (day <= monthLength && (i > 0 || j >= startingDay)) {
-          let className = undefined;
-          let ariaSelected = false;
+          let classNames = ['pe-auto', 'rounded-0'];
+          let ariaSelected = undefined;
           const dayIndex = day;
           const date = new Date(year, month, day, 12, 0, 0, 0);
           const localizedDate = dayjs(date).format('dddd, MMMM D, YYYY');
@@ -163,18 +163,16 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
           const isCurrentDate =
             Date.parse(dateString) === Date.parse(currentDate.toISOString());
           let clickHandler: React.MouseEventHandler | undefined = handleClick;
-          const style = {
-            cursor: 'pointer',
-            borderRadius: 0,
-          };
           if (isCurrentDate) {
             // if date is the current Date
-            className = 'text-primary';
+            classNames.push('text-primary');
           }
           if (beforeMinDate || afterMaxDate) {
-            className = 'text-muted';
+            classNames.push('text-muted');
+            classNames = classNames.filter((c) => c !== 'pe-auto');
+            classNames.push('pe-none');
+
             clickHandler = undefined;
-            style.cursor = 'default';
           }
           if (
             processedSelectedDate &&
@@ -182,27 +180,24 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
           ) {
             ariaSelected = true;
             if (processedSelectedDate instanceof Date) {
-              className = 'bg-primary-600 text-white';
+              classNames.push('bg-primary-600');
+              classNames.push('text-white');
             } else {
               const { start, end } = processedSelectedDate;
-              className = 'bg-primary-100';
-
               if (
-                start &&
-                start.getDate() === day &&
-                start.getMonth() === month &&
-                start.getFullYear() === year
+                (start &&
+                  start.getDate() === day &&
+                  start.getMonth() === month &&
+                  start.getFullYear() === year) ||
+                (end &&
+                  end.getDate() === day &&
+                  end.getMonth() === month &&
+                  end.getFullYear() === year)
               ) {
-                className = 'bg-primary-600 text-white';
-              }
-
-              if (
-                end &&
-                end.getDate() === day &&
-                end.getMonth() === month &&
-                end.getFullYear() === year
-              ) {
-                className = 'bg-primary-600 text-white';
+                classNames.push('bg-primary-600');
+                classNames.push('text-white');
+              } else {
+                classNames.push('bg-primary-100');
               }
             }
           }
@@ -210,13 +205,13 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
           week.push(
             <td
               key={j}
+              role="button"
               aria-label={localizedDate}
               aria-selected={ariaSelected}
               aria-current={isCurrentDate ? 'date' : undefined}
               data-day={day}
               onClick={clickHandler}
-              style={style}
-              className={className}
+              className={classNames.join(' ')}
               tabIndex={-1}
               ref={(el) =>
                 props.dayRefs.current

--- a/src/DatePicker/Calendar.tsx
+++ b/src/DatePicker/Calendar.tsx
@@ -160,15 +160,14 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
           const afterMaxDate =
             maximumDate &&
             Date.parse(dateString) > Date.parse(maximumDate.toISOString());
-
+          const isCurrentDate =
+            Date.parse(dateString) === Date.parse(currentDate.toISOString());
           let clickHandler: React.MouseEventHandler | undefined = handleClick;
           const style = {
             cursor: 'pointer',
             borderRadius: 0,
           };
-          if (
-            Date.parse(dateString) === Date.parse(currentDate.toISOString())
-          ) {
+          if (isCurrentDate) {
             // if date is the current Date
             className = 'text-primary';
           }
@@ -213,6 +212,7 @@ export const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
               key={j}
               aria-label={localizedDate}
               aria-selected={ariaSelected}
+              aria-current={isCurrentDate ? 'date' : undefined}
               data-day={day}
               onClick={clickHandler}
               style={style}

--- a/src/DatePicker/CalendarHeader.tsx
+++ b/src/DatePicker/CalendarHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import DatePickerContext from './DatePickerContext';
 import { calculateYearRange } from './YearView';
 
-interface CalendarHeaderProps {
+interface CalendarHeaderProps{
   displayDate: Date;
   onChange: (date: Date) => void;
   resetFocusOnHeader: () => void;
@@ -141,11 +141,16 @@ const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
     };
 
     const renderPreviousButton = () => {
+      const ariaLabels = {
+        day: "Show previous month", 
+        month: "Show previous year",
+        year: "Show previous 12 years"
+      }
       const previousButton = (
         <button
           onClick={handleClickPrevious}
           onKeyDown={handlePressPrevious}
-          aria-label={`previous ${view}`}
+          aria-label={ariaLabels[view]}
         >
           <i className="bi bi-chevron-left"></i>
         </button>
@@ -181,42 +186,57 @@ const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
           return previousButton;
       }
     };
-
+    const renderNextButton = () => {
+      const ariaLabels = {
+        day: "Show next month", 
+        month: "Show next year",
+        year: "Show next 12 years"
+      }
+      return (
+        <button
+        onClick={handleClickNext}
+        onKeyDown={handlePressNext}
+        aria-label={ariaLabels[view]}
+      >
+        <i className="bi bi-chevron-right"></i>
+      </button>
+      )
+    }
     const renderHeader = () => {
+      let header: string = ""
+      let ariaLabel: string = ""
+      const [displayMonth, displayYear] = [props.displayDate.getMonth(),props.displayDate.getFullYear() ]
+      const { startLimit, endLimit } = calculateYearRange(props.displayDate);
+      if (view === 'day'){
+        header = `${
+          MONTH_LABELS[displayMonth]
+        } ${displayYear}`
+      }
       if (view === 'month') {
-        return `${props.displayDate.getFullYear()}`;
+        header = `${displayYear}`;
       }
       if (view === 'year') {
-        const { startLimit, endLimit } = calculateYearRange(props.displayDate);
-        return `${startLimit} - ${endLimit}`;
+        header = `${startLimit} - ${endLimit}`;
       }
 
-      return `${
-        MONTH_LABELS[props.displayDate.getMonth()]
-      } ${props.displayDate.getFullYear()}`;
+      return (
+        <button
+        onClick={changeView}
+        onKeyDown={handlePressChangeView}
+        aria-disabled={view === 'year'}
+        aria-live="polite"
+        aria-label={ariaLabel}
+      >
+        {header}
+      </button>
+      )
     };
 
     return (
       <div className="text-center d-flex justify-content-between" ref={ref}>
         {renderPreviousButton()}
-
-        <button
-          id="id-grid-label"
-          onClick={changeView}
-          onKeyDown={handlePressChangeView}
-          // disabled={view === 'year'}
-          aria-live="polite"
-        >
-          {renderHeader()}
-        </button>
-
-        <button
-          onClick={handleClickNext}
-          onKeyDown={handlePressNext}
-          aria-label={`next ${view}`}
-        >
-          <i className="bi bi-chevron-right"></i>
-        </button>
+      {renderHeader()}
+        {renderNextButton()}
       </div>
     );
   }

--- a/src/DatePicker/CalendarHeader.tsx
+++ b/src/DatePicker/CalendarHeader.tsx
@@ -224,6 +224,7 @@ const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
         onClick={changeView}
         onKeyDown={handlePressChangeView}
         aria-disabled={view === 'year'}
+        className={view === 'year' ? "disabled" : undefined}
         aria-live="polite"
         aria-label={ariaLabel}
       >

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -648,7 +648,6 @@ export const DatePicker: BsPrefixRefForwardingComponent<
       if (nextShow) {
         setShowCalendar(true);
       } else {
-        dropdownToggleRef?.current?.focus();
         setShowCalendar(false);
       }
     };
@@ -839,9 +838,9 @@ export const DatePicker: BsPrefixRefForwardingComponent<
 
     const ariaLabelsForMenu = {
       day: 'Choose date',
-      month: 'Choose month', 
-      year: 'Choose year'
-    }
+      month: 'Choose month',
+      year: 'Choose year',
+    };
     return (
       <DatePickerContext.Provider value={contextValue}>
         <Dropdown

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -463,7 +463,6 @@ export const DatePicker: BsPrefixRefForwardingComponent<
 
     const calendarHeader = (
       <CalendarHeader
-        // id={calendarHeaderId}
         displayDate={state.displayDate as Date}
         onChange={onChangeMonth}
         resetFocusOnHeader={resetFocusOnHeader}
@@ -537,12 +536,12 @@ export const DatePicker: BsPrefixRefForwardingComponent<
     const enterDateSingle = (event: React.ChangeEvent<HTMLInputElement>) => {
       const enteredDate = event.target.value;
       const parsedDate = dayjs(enteredDate, dateFormat).toDate();
-      const afterMinDate =
-        props.minDate &&
-        setTimeToNoon(parsedDate) >= setTimeToNoon(new Date(props.minDate));
-      const beforeMaxDate =
-        props.maxDate &&
-        setTimeToNoon(parsedDate) <= setTimeToNoon(new Date(props.maxDate));
+      const afterMinDate = props.minDate
+        ? setTimeToNoon(parsedDate) >= setTimeToNoon(new Date(props.minDate))
+        : true;
+      const beforeMaxDate = props.maxDate
+        ? setTimeToNoon(parsedDate) <= setTimeToNoon(new Date(props.maxDate))
+        : true;
       if (
         isValidDate(enteredDate, dateFormat) &&
         parsedDate.getFullYear() >= 1900 &&

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -212,7 +212,6 @@ export const DatePicker: BsPrefixRefForwardingComponent<
     const dayRefs = React.useRef<Array<HTMLTableCellElement | null>>([]);
     const monthRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
     const yearRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
-
     const getinitialInputDate = () => {
       if (!props.initialValue) {
         if (isRange) {
@@ -464,6 +463,7 @@ export const DatePicker: BsPrefixRefForwardingComponent<
 
     const calendarHeader = (
       <CalendarHeader
+        // id={calendarHeaderId}
         displayDate={state.displayDate as Date}
         onChange={onChangeMonth}
         resetFocusOnHeader={resetFocusOnHeader}
@@ -837,6 +837,11 @@ export const DatePicker: BsPrefixRefForwardingComponent<
       }
     }, [showCalendar, displayDate]);
 
+    const ariaLabelsForMenu = {
+      day: 'Choose date',
+      month: 'Choose month', 
+      year: 'Choose year'
+    }
     return (
       <DatePickerContext.Provider value={contextValue}>
         <Dropdown
@@ -888,7 +893,7 @@ export const DatePicker: BsPrefixRefForwardingComponent<
             as="div"
             role="dialog"
             aria-modal="true"
-            aria-label="Choose Date"
+            aria-label={ariaLabelsForMenu[view]}
           >
             <Dropdown.Header className="datepicker-header" role="none">
               {calendarHeader}

--- a/src/DatePicker/MonthView.tsx
+++ b/src/DatePicker/MonthView.tsx
@@ -230,15 +230,19 @@ export const MonthView = React.forwardRef<HTMLDivElement, MonthViewProps>(
       <div className="sgds monthpicker" ref={ref} {...props}>
         {MONTH_LABELS.map((month, index) => {
           const activeMonthClass = getActiveMonthClass(month);
-
+          const isCurrentMonthAndYear =
+            MONTH_LABELS[CURRENT_DATE.getMonth()] === month &&
+            displayDate.getFullYear() === CURRENT_DATE.getFullYear();
+          const defaultAriaLabel = `${month} ${displayDate.getFullYear()}`;
+          const currentMonthAriaLabel = `Current month, ${defaultAriaLabel}`;
           return (
             <button
-              aria-label={`${month} ${displayDate.getFullYear()}`}
-              aria-selected={activeMonthClass ? "true" : "false"}
+              aria-label={
+                isCurrentMonthAndYear ? currentMonthAriaLabel : defaultAriaLabel
+              }
+              aria-selected={activeMonthClass ? 'true' : 'false'}
               className={classNames(
-                MONTH_LABELS[CURRENT_DATE.getMonth()] === month &&
-                  displayDate.getFullYear() === CURRENT_DATE.getFullYear() &&
-                  'text-primary',
+                isCurrentMonthAndYear && 'text-primary',
                 activeMonthClass,
                 'month'
               )}

--- a/src/DatePicker/MonthView.tsx
+++ b/src/DatePicker/MonthView.tsx
@@ -16,18 +16,18 @@ export interface MonthViewProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 export const MONTH_LABELS = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
+  'January',
+  'February',
+  'March',
+  'April',
   'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
 ];
 
 const CURRENT_DATE = new Date();
@@ -226,7 +226,6 @@ export const MonthView = React.forwardRef<HTMLDivElement, MonthViewProps>(
 
       return undefined;
     };
-
     return (
       <div className="sgds monthpicker" ref={ref} {...props}>
         {MONTH_LABELS.map((month, index) => {
@@ -234,6 +233,8 @@ export const MonthView = React.forwardRef<HTMLDivElement, MonthViewProps>(
 
           return (
             <button
+              aria-label={`${month} ${displayDate.getFullYear()}`}
+              aria-selected={activeMonthClass ? "true" : "false"}
               className={classNames(
                 MONTH_LABELS[CURRENT_DATE.getMonth()] === month &&
                   displayDate.getFullYear() === CURRENT_DATE.getFullYear() &&
@@ -248,7 +249,7 @@ export const MonthView = React.forwardRef<HTMLDivElement, MonthViewProps>(
                 monthRefs.current ? (monthRefs.current[index] = el) : undefined
               }
             >
-              {month}
+              {month.slice(0, 3)}
             </button>
           );
         })}

--- a/src/DatePicker/YearView.tsx
+++ b/src/DatePicker/YearView.tsx
@@ -196,6 +196,7 @@ export const YearView = React.forwardRef<HTMLDivElement, YearViewProps>(
           const activeYearClass = getActiveYearClass(year);
           return (
             <button
+              aria-selected={activeYearClass ? 'true' : 'false'}
               className={classNames(
                 CURRENT_YEAR === year && 'text-primary',
                 activeYearClass,

--- a/src/DatePicker/YearView.tsx
+++ b/src/DatePicker/YearView.tsx
@@ -194,11 +194,13 @@ export const YearView = React.forwardRef<HTMLDivElement, YearViewProps>(
       <div className="sgds yearpicker" ref={ref} {...props}>
         {yearArray.map((year, index) => {
           const activeYearClass = getActiveYearClass(year);
+          const isCurrentYear =  CURRENT_YEAR === year
           return (
             <button
               aria-selected={activeYearClass ? 'true' : 'false'}
+              aria-label={isCurrentYear ? `Current year, ${year}` : undefined}
               className={classNames(
-                CURRENT_YEAR === year && 'text-primary',
+                isCurrentYear && 'text-primary',
                 activeYearClass,
                 'year'
               )}

--- a/stories/DatePicker/DatePicker.stories.mdx
+++ b/stories/DatePicker/DatePicker.stories.mdx
@@ -13,24 +13,10 @@ import { argTypes } from './argTypes';
 />
 
 export const DatePickerTemplate = (args) => {
-  const [date, setDate] = useState(new Date('2020-01-01'));
-  const ref = React.createRef();
-  const handleChange = (value) => {
-    setDate(value);
-  };
-  const minDate = new Date(2020, 10, 11, 12, 0, 0, 0).toISOString();
-  const maxDate = new Date(2020, 10, 13, 12, 0, 0, 0).toISOString();
   return <DatePicker {...args} />;
 };
 
-export const DatePickerTemplateWithText = (args) => {
-  const [date, setDate] = useState(new Date('2020-01-01'));
-  const ref = React.createRef();
-  const handleChange = (value) => {
-    setDate(value);
-  };
-  const minDate = new Date('2024-01-01').toISOString();
-  const maxDate = new Date('2024-01-31').toISOString();
+export const DatePickerMinMaxDates = (args) => {
   return (
     <>
       <Form.Text className="text-muted" id="minAndMaxDate">
@@ -47,7 +33,7 @@ The `DatePicker` Component is built using `Dropdown`, `FormControl` and `Button`
 By default, the Calendar points to current date and input has no value. Users can either enter the dates in the `FormControl` input or pick dates using the Calendar.
 
 <Canvas>
-  <Story name="Basic" args={{}} height="500px">
+  <Story name="Basic" height="500px">
     {DatePickerTemplate.bind({})}
   </Story>
 </Canvas>
@@ -186,7 +172,7 @@ displayDate: Date;
   }}
   height="500px"
 >
-  {DatePickerTemplateWithText.bind({})}
+  {DatePickerMinMaxDates.bind({})}
 </Story>
 
 ## Callback Functions

--- a/tests/DatePicker/Calendar.test.tsx
+++ b/tests/DatePicker/Calendar.test.tsx
@@ -453,4 +453,22 @@ describe('Calendar a11y', () => {
     }
     expect(getByText('24').getAttribute('aria-selected')).toEqual('false');
   });
+
+  it("aria-current=date for today's date", () => {
+    const displayDate = new Date();
+    const { getByText } = render(
+      <Calendar
+        selectedDate={undefined}
+        displayDate={displayDate}
+        changeDate={mockChangeDate}
+        mode="range"
+        show={true}
+        dayRefs={dayRefs}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+      />
+    );
+    const day = new Date().getDate();
+    expect(getByText(`${day}`).getAttribute("aria-current")).toEqual('date')
+  });
 });

--- a/tests/DatePicker/Calendar.test.tsx
+++ b/tests/DatePicker/Calendar.test.tsx
@@ -240,8 +240,7 @@ describe('Single mode Calendar', () => {
     );
     const activeRange = [15, 16, 17, 18, 19, 20, 21];
     activeRange.forEach((day) => {
-      expect(getByText(day).classList).not.toContain('text-muted');
-      expect(getByText(day).classList).toContain('pe-auto');
+      expect(getByText(day).classList).not.toContain('disabled');
     });
 
     fireEvent.click(getByText('21'));
@@ -256,16 +255,13 @@ describe('Single mode Calendar', () => {
       mockChangeDate.mockReset();
     });
     fireEvent.click(getByText('14'));
-    expect(getByText('14').classList).toContain('text-muted');
-    expect(getByText('14').classList).toContain('pe-none');
-    expect(getByText('14').classList).not.toContain('pe-auto');
+    expect(getByText('14').classList).toContain('disabled');
     await waitFor(() => {
       expect(mockChangeDate).not.toHaveBeenCalled();
       mockChangeDate.mockReset();
     });
     fireEvent.click(getByText('22'));
-    expect(getByText('22').classList).toContain('text-muted');
-    expect(getByText('22').classList).toContain('pe-none');
+    expect(getByText('22').classList).toContain('disabled');
     await waitFor(() => {
       expect(mockChangeDate).not.toHaveBeenCalled();
       mockChangeDate.mockReset();

--- a/tests/DatePicker/Calendar.test.tsx
+++ b/tests/DatePicker/Calendar.test.tsx
@@ -381,3 +381,76 @@ describe('Range Calendar', () => {
     });
   });
 });
+
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+
+dayjs.extend(localizedFormat);
+
+describe('Calendar a11y', () => {
+  const mode = 'single';
+  const mockChangeDate = jest.fn();
+  const mockOnChangeMonth = jest.fn();
+  const mockhandleTabPressOnCalendarBody = jest.fn();
+  const dayRefs = React.createRef<Array<HTMLTableCellElement | null>>();
+  it('date in calendar is aria-labelled', () => {
+    const displayDate = new Date(2022, 2, 21);
+    const selectedDate = new Date(2022, 2, 18);
+    const { getByText } = render(
+      <Calendar
+        selectedDate={selectedDate}
+        displayDate={displayDate}
+        changeDate={mockChangeDate}
+        mode={mode}
+        show={true}
+        dayRefs={dayRefs}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+      />
+    );
+    const expected = dayjs(new Date(2022, 2, 1)).format('dddd, MMMM D, YYYY');
+    expect(getByText('1').getAttribute('aria-label')).toEqual(expected);
+  });
+
+  it('aria-selected=true on selectedDate, single mode', () => {
+    const displayDate = new Date(2022, 2, 21);
+    const selectedDate = new Date(2022, 2, 18);
+    const { getByText } = render(
+      <Calendar
+        selectedDate={selectedDate}
+        displayDate={displayDate}
+        changeDate={mockChangeDate}
+        mode={mode}
+        show={true}
+        dayRefs={dayRefs}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+      />
+    );
+    expect(getByText('18').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('21').getAttribute('aria-selected')).toEqual('false');
+  });
+  it('aria-selected=true on selectedDate, range mode', () => {
+    const displayDate = new Date(2022, 2, 21);
+    const selectedDate = {
+      start: new Date(2022, 2, 18),
+      end: new Date(2022, 2, 23),
+    };
+    const { getByText } = render(
+      <Calendar
+        selectedDate={selectedDate}
+        displayDate={displayDate}
+        changeDate={mockChangeDate}
+        mode="range"
+        show={true}
+        dayRefs={dayRefs}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+      />
+    );
+    for (let i = 18; i < 24; i++) {
+      expect(getByText(`${i}`).getAttribute('aria-selected')).toEqual('true');
+    }
+    expect(getByText('24').getAttribute('aria-selected')).toEqual('false');
+  });
+});

--- a/tests/DatePicker/Calendar.test.tsx
+++ b/tests/DatePicker/Calendar.test.tsx
@@ -241,7 +241,7 @@ describe('Single mode Calendar', () => {
     const activeRange = [15, 16, 17, 18, 19, 20, 21];
     activeRange.forEach((day) => {
       expect(getByText(day).classList).not.toContain('text-muted');
-      expect(getByText(day).style.cursor).toEqual('pointer');
+      expect(getByText(day).classList).toContain('pe-auto');
     });
 
     fireEvent.click(getByText('21'));
@@ -257,14 +257,15 @@ describe('Single mode Calendar', () => {
     });
     fireEvent.click(getByText('14'));
     expect(getByText('14').classList).toContain('text-muted');
-    expect(getByText('14').style.cursor).toEqual('default');
+    expect(getByText('14').classList).toContain('pe-none');
+    expect(getByText('14').classList).not.toContain('pe-auto');
     await waitFor(() => {
       expect(mockChangeDate).not.toHaveBeenCalled();
       mockChangeDate.mockReset();
     });
     fireEvent.click(getByText('22'));
     expect(getByText('22').classList).toContain('text-muted');
-    expect(getByText('22').style.cursor).toEqual('default');
+    expect(getByText('22').classList).toContain('pe-none');
     await waitFor(() => {
       expect(mockChangeDate).not.toHaveBeenCalled();
       mockChangeDate.mockReset();
@@ -428,7 +429,7 @@ describe('Calendar a11y', () => {
       />
     );
     expect(getByText('18').getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('21').getAttribute('aria-selected')).toEqual('false');
+    expect(getByText('21').getAttribute('aria-selected')).toBeNull();
   });
   it('aria-selected=true on selectedDate, range mode', () => {
     const displayDate = new Date(2022, 2, 21);
@@ -451,7 +452,7 @@ describe('Calendar a11y', () => {
     for (let i = 18; i < 24; i++) {
       expect(getByText(`${i}`).getAttribute('aria-selected')).toEqual('true');
     }
-    expect(getByText('24').getAttribute('aria-selected')).toEqual('false');
+    expect(getByText('24').getAttribute('aria-selected')).toBeNull();
   });
 
   it("aria-current=date for today's date", () => {
@@ -469,6 +470,6 @@ describe('Calendar a11y', () => {
       />
     );
     const day = new Date().getDate();
-    expect(getByText(`${day}`).getAttribute("aria-current")).toEqual('date')
+    expect(getByText(`${day}`).getAttribute('aria-current')).toEqual('date');
   });
 });

--- a/tests/DatePicker/DatePicker.test.tsx
+++ b/tests/DatePicker/DatePicker.test.tsx
@@ -2167,4 +2167,21 @@ describe('Datepicker a11y', () => {
       container.querySelector('div[role="dialog"]')?.getAttribute('aria-label')
     ).toEqual('Choose year');
   });
+
+  it('datepicker focuses on input element when it calendar closes', async () => {
+    const { container, getByText } = render(
+      <DatePicker displayDate={new Date('2020-01-01')} />
+    );
+    fireEvent.click(container.querySelector('button.dropdown-toggle')!);
+    await waitFor(() =>
+      expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
+    );
+    fireEvent.click(getByText("2"))
+    await waitFor(() => {
+      expect(
+        container.querySelector('.dropdown-menu.show')
+      ).not.toBeInTheDocument();
+    });
+    expect(container.querySelector('input')).toHaveFocus();
+  });
 });

--- a/tests/DatePicker/DatePicker.test.tsx
+++ b/tests/DatePicker/DatePicker.test.tsx
@@ -596,7 +596,7 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('previous day')).toHaveFocus();
+      expect(getByLabelText('Show previous month')).toHaveFocus();
     });
   });
 
@@ -615,7 +615,7 @@ describe('DatePicker', () => {
       expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
     );
 
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -646,7 +646,7 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('next day')).toHaveFocus();
+      expect(getByLabelText('Show next month')).toHaveFocus();
     });
   });
 
@@ -661,7 +661,7 @@ describe('DatePicker', () => {
       expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
     );
 
-    fireEvent.keyDown(getByLabelText('next day'), {
+    fireEvent.keyDown(getByLabelText('Show next month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -687,7 +687,7 @@ describe('DatePicker', () => {
       shiftKey: true,
     });
     await waitFor(() => {
-      expect(getByLabelText('next day')).toHaveFocus();
+      expect(getByLabelText('Show next month')).toHaveFocus();
     });
   });
 
@@ -706,7 +706,7 @@ describe('DatePicker', () => {
       expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
     );
 
-    fireEvent.keyDown(getByLabelText('next day'), {
+    fireEvent.keyDown(getByLabelText('Show next month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -739,7 +739,7 @@ describe('DatePicker', () => {
       shiftKey: true,
     });
     await waitFor(() => {
-      expect(getByLabelText('previous day')).toHaveFocus();
+      expect(getByLabelText('Show previous month')).toHaveFocus();
     });
   });
 
@@ -754,7 +754,7 @@ describe('DatePicker', () => {
       expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
     );
 
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -788,10 +788,10 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('previous day')).toHaveFocus();
+      expect(getByLabelText('Show previous month')).toHaveFocus();
     });
 
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Enter',
       code: 'Enter',
       keyCode: 13,
@@ -827,10 +827,10 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('previous day')).toHaveFocus();
+      expect(getByLabelText('Show previous month')).toHaveFocus();
     });
 
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Enter',
       code: 'Enter',
       keyCode: 13,
@@ -842,7 +842,7 @@ describe('DatePicker', () => {
       expect(getByText(`${newMonth} ${newYear}`)).toBeInTheDocument();
     });
 
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -852,7 +852,7 @@ describe('DatePicker', () => {
       code: 'Tab',
       keyCode: 9,
     });
-    fireEvent.keyDown(getByLabelText('next day'), {
+    fireEvent.keyDown(getByLabelText('Show next month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -886,10 +886,10 @@ describe('DatePicker', () => {
       shiftKey: true,
     });
     await waitFor(() => {
-      expect(getByLabelText('next day')).toHaveFocus();
+      expect(getByLabelText('Show next month')).toHaveFocus();
     });
 
-    fireEvent.keyDown(getByLabelText('next day'), {
+    fireEvent.keyDown(getByLabelText('Show next month'), {
       key: 'Enter',
       code: 'Enter',
       keyCode: 13,
@@ -928,10 +928,10 @@ describe('DatePicker', () => {
       shiftKey: true,
     });
     await waitFor(() => {
-      expect(getByLabelText('next day')).toHaveFocus();
+      expect(getByLabelText('Show next month')).toHaveFocus();
     });
 
-    fireEvent.keyDown(getByLabelText('next day'), {
+    fireEvent.keyDown(getByLabelText('Show next month'), {
       key: 'Enter',
       code: 'Enter',
       keyCode: 13,
@@ -943,7 +943,7 @@ describe('DatePicker', () => {
       expect(getByText(`${newMonth} ${newYear}`)).toBeInTheDocument();
     });
 
-    fireEvent.keyDown(getByLabelText('next day'), {
+    fireEvent.keyDown(getByLabelText('Show next month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -976,7 +976,7 @@ describe('DatePicker', () => {
       code: 'Tab',
       keyCode: 9,
     });
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -1246,7 +1246,7 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('previous month')).toHaveFocus();
+      expect(getByLabelText('Show previous year')).toHaveFocus();
     });
   });
 
@@ -1284,7 +1284,7 @@ describe('DatePicker', () => {
       ).toEqual(`${displayMonthShort}`);
     });
 
-    fireEvent.keyDown(getByLabelText('previous month'), {
+    fireEvent.keyDown(getByLabelText('Show previous year'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -1334,7 +1334,7 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('next month')).toHaveFocus();
+      expect(getByLabelText('Show next year')).toHaveFocus();
     });
   });
 
@@ -1372,7 +1372,7 @@ describe('DatePicker', () => {
       ).toEqual(`${displayMonthShort}`);
     });
 
-    fireEvent.keyDown(getByLabelText('next month'), {
+    fireEvent.keyDown(getByLabelText('Show next year'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -1611,7 +1611,7 @@ describe('DatePicker', () => {
       code: 'Tab',
       keyCode: 9,
     });
-    fireEvent.keyDown(getByLabelText('previous day'), {
+    fireEvent.keyDown(getByLabelText('Show previous month'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -1641,7 +1641,7 @@ describe('DatePicker', () => {
       code: 'Tab',
       keyCode: 9,
     });
-    fireEvent.keyDown(getByLabelText('previous month'), {
+    fireEvent.keyDown(getByLabelText('Show previous year'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -1713,7 +1713,7 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('previous year')).toHaveFocus();
+      expect(getByLabelText('Show previous 12 years')).toHaveFocus();
     });
   });
 
@@ -1755,7 +1755,7 @@ describe('DatePicker', () => {
       ).toEqual(`${displayYear}`);
     });
 
-    fireEvent.keyDown(getByLabelText('previous year'), {
+    fireEvent.keyDown(getByLabelText('Show previous 12 years'), {
       key: 'Tab',
       code: 'Tab',
       keyCode: 9,
@@ -1809,7 +1809,7 @@ describe('DatePicker', () => {
       keyCode: 9,
     });
     await waitFor(() => {
-      expect(getByLabelText('next year')).toHaveFocus();
+      expect(getByLabelText('Show next 12 years')).toHaveFocus();
     });
   });
 
@@ -2134,5 +2134,37 @@ describe('Datepicker Range mode', () => {
         '01/01/2020 - 20/01/2020'
       )
     );
+  });
+});
+
+describe('Datepicker a11y', () => {
+  it("dialog's aria-label changes by view", async () => {
+    const { getByText, container } = render(
+      <DatePicker mode="range" displayDate={new Date('2020-01-01')} />
+    );
+    fireEvent.click(container.querySelector('button.dropdown-toggle')!);
+    await waitFor(() =>
+      expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
+    );
+
+    expect(
+      container.querySelector('div[role="dialog"]')?.getAttribute('aria-label')
+    ).toEqual('Choose date');
+    fireEvent.click(getByText('January 2020'));
+    await waitFor(() => {
+      expect(getByText('2020')).toBeInTheDocument();
+    });
+    expect(
+      container.querySelector('div[role="dialog"]')?.getAttribute('aria-label')
+    ).toEqual('Choose month');
+    fireEvent.click(getByText('2020'));
+    await waitFor(() => {
+      expect(
+        container.querySelector('button[aria-label="Show previous 12 years"]')
+      ).toBeInTheDocument();
+    });
+    expect(
+      container.querySelector('div[role="dialog"]')?.getAttribute('aria-label')
+    ).toEqual('Choose year');
   });
 });

--- a/tests/DatePicker/DatePicker.test.tsx
+++ b/tests/DatePicker/DatePicker.test.tsx
@@ -1878,6 +1878,20 @@ describe('DatePicker', () => {
       expect(getByText('Please enter a valid date')).toBeInTheDocument();
     });
   });
+  it('when a date is typed into input, it updates the calendar view', async () => {
+    const displayDate = new Date(2024, 3, 12);
+    const { container, getByText } = render(
+      <DatePicker displayDate={displayDate} />
+    );
+    const input = container.querySelector('input')!;
+    const toggleButton = container.querySelector('.dropdown-toggle')!;
+    fireEvent.click(toggleButton);
+    await waitFor(() => expect(getByText('April 2024')).toBeInTheDocument());
+
+    fireEvent.change(input, { target: { value: '01012020' } });
+    fireEvent.click(toggleButton);
+    await waitFor(() => expect(getByText('January 2020')).toBeInTheDocument());
+  });
 });
 
 describe('Datepicker Range mode', () => {
@@ -2176,7 +2190,7 @@ describe('Datepicker a11y', () => {
     await waitFor(() =>
       expect(container.querySelector('.dropdown-menu.show')).toBeInTheDocument()
     );
-    fireEvent.click(getByText("2"))
+    fireEvent.click(getByText('2'));
     await waitFor(() => {
       expect(
         container.querySelector('.dropdown-menu.show')

--- a/tests/DatePicker/MonthView.test.tsx
+++ b/tests/DatePicker/MonthView.test.tsx
@@ -65,7 +65,7 @@ describe('MonthView a11y', () => {
     const { getByText } = render(
       <MonthView
         onClickMonth={mockFn}
-        selectedDate={selectedDate}
+        selectedDate={new Date(2024, 3, 11)}
         displayDate={displayDate}
         show={true}
         onChangeMonth={mockOnChangeMonth}
@@ -119,4 +119,22 @@ describe('MonthView a11y', () => {
       );
     }
   });
+  it("current month should be indicated in aria-label" , () => {
+    const { getByText } = render(
+      <MonthView
+        onClickMonth={mockFn}
+        selectedDate={undefined}
+        displayDate={displayDate}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        monthRefs={monthRefs}
+      />
+    );
+    const currentMonth = new Date().getMonth()
+    const currentMonthName = MONTH_LABELS[currentMonth].slice(0,3)
+    expect(getByText(currentMonthName).getAttribute('aria-label')).toContain(
+      "Current month"
+    );
+  })
 });

--- a/tests/DatePicker/MonthView.test.tsx
+++ b/tests/DatePicker/MonthView.test.tsx
@@ -28,7 +28,7 @@ describe('MonthView', () => {
       container.querySelectorAll('button.month.text-primary').length
     ).toEqual(1);
     expect(container.querySelector('button.text-primary')?.textContent).toEqual(
-      MONTH_LABELS[displayDate.getMonth()]
+      MONTH_LABELS[displayDate.getMonth()].slice(0, 3)
     );
   });
 
@@ -51,5 +51,72 @@ describe('MonthView', () => {
     fireEvent.click(buttonOne);
 
     expect(mockFn).toHaveBeenCalled();
+  });
+});
+
+describe('MonthView a11y', () => {
+  const mockFn = jest.fn();
+  const mockhandleTabPressOnCalendarBody = jest.fn();
+  const mockOnChangeMonth = jest.fn();
+  const monthRefs = React.createRef<Array<HTMLButtonElement | null>>();
+  const selectedDate = new Date();
+  const displayDate = new Date();
+  it('should have aria-label in format of Month Year', () => {
+    const { getByText } = render(
+      <MonthView
+        onClickMonth={mockFn}
+        selectedDate={selectedDate}
+        displayDate={displayDate}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        monthRefs={monthRefs}
+      />
+    );
+    expect(getByText('Jan').getAttribute('aria-label')).toEqual(
+      `January ${selectedDate.getFullYear()}`
+    );
+  });
+  it('selected month should have aria-selected=true, mode=single', () => {
+    const { getByText } = render(
+      <MonthView
+        onClickMonth={mockFn}
+        selectedDate={new Date(2020, 3, 1)}
+        displayDate={new Date(2020, 3, 1)}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        monthRefs={monthRefs}
+      />
+    );
+    expect(getByText('Apr').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Jun').getAttribute('aria-selected')).toEqual('false');
+  });
+  it('selected month should have aria-selected=true, mode=range', () => {
+    const { getByText } = render(
+      <MonthView
+        onClickMonth={mockFn}
+        selectedDate={{
+          start: new Date(2020, 3, 1),
+          end: new Date(2020, 11, 1),
+        }}
+        displayDate={new Date(2020, 3, 1)}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        monthRefs={monthRefs}
+      />
+    );
+    const monthAbbr = (i: number) => MONTH_LABELS[i].slice(0, 3);
+    for (let i = 3; i < 12; i++) {
+      expect(getByText(monthAbbr(i)).getAttribute('aria-selected')).toEqual(
+        'true'
+      );
+    }
+    for (let i = 0; i < 3; i++) {
+      expect(getByText(monthAbbr(i)).getAttribute('aria-selected')).toEqual(
+        'false'
+      );
+    }
   });
 });

--- a/tests/DatePicker/YearView.test.tsx
+++ b/tests/DatePicker/YearView.test.tsx
@@ -115,4 +115,23 @@ describe('YearView a11y', () => {
     }
     expect(getByText('2019').getAttribute('aria-selected')).toEqual('false');
   });
+
+  it('current year should be indicated in aria-label', () => {
+    const { getByText } = render(
+      <YearView
+        onClickYear={mockFn}
+        selectedDate={undefined}
+        displayDate={new Date()}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        yearRefs={yearRefs}
+      />
+    );
+    const currentYear = new Date().getFullYear()
+    expect(getByText(`${currentYear}`).getAttribute('aria-label')).toContain(
+      "Current year"
+    );
+  });
+
 });

--- a/tests/DatePicker/YearView.test.tsx
+++ b/tests/DatePicker/YearView.test.tsx
@@ -73,3 +73,46 @@ describe('YearView', () => {
     expect(mockFn).toHaveBeenCalled();
   });
 });
+
+describe('YearView a11y', () => {
+  const mockFn = jest.fn();
+  const mockhandleTabPressOnCalendarBody = jest.fn();
+  const mockOnChangeMonth = jest.fn();
+  const yearRefs = React.createRef<Array<HTMLButtonElement | null>>();
+  it('selected year should have aria-selected=true, mode=single', () => {
+    const { getByText } = render(
+      <YearView
+        onClickYear={mockFn}
+        selectedDate={new Date(2020, 3, 1)}
+        displayDate={new Date(2020, 3, 1)}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        yearRefs={yearRefs}
+      />
+    );
+    expect(getByText('2020').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('2021').getAttribute('aria-selected')).toEqual('false');
+    expect(getByText('2019').getAttribute('aria-selected')).toEqual('false');
+  });
+  it('selected year should have aria-selected=true, mode=range', () => {
+    const { getByText } = render(
+      <YearView
+        onClickYear={mockFn}
+        selectedDate={{
+          start: new Date(2020, 3, 1),
+          end: new Date(2022, 3, 1),
+        }}
+        displayDate={new Date(2020, 3, 1)}
+        show={true}
+        onChangeMonth={mockOnChangeMonth}
+        handleTabPressOnCalendarBody={mockhandleTabPressOnCalendarBody}
+        yearRefs={yearRefs}
+      />
+    );
+    for (let i = 2020; i < 2023; i++) {
+      expect(getByText(`${i}`).getAttribute('aria-selected')).toEqual('true');
+    }
+    expect(getByText('2019').getAttribute('aria-selected')).toEqual('false');
+  });
+});

--- a/tests/DatePicker/__snapshots__/CalendarHeader.test.tsx.snap
+++ b/tests/DatePicker/__snapshots__/CalendarHeader.test.tsx.snap
@@ -6,20 +6,21 @@ exports[`CalendarHeader should have default html structure 1`] = `
     class="text-center d-flex justify-content-between"
   >
     <button
-      aria-label="previous day"
+      aria-label="Show previous month"
     >
       <i
         class="bi bi-chevron-left"
       />
     </button>
     <button
+      aria-disabled="false"
+      aria-label=""
       aria-live="polite"
-      id="id-grid-label"
     >
       March 2022
     </button>
     <button
-      aria-label="next day"
+      aria-label="Show next month"
     >
       <i
         class="bi bi-chevron-right"


### PR DESCRIPTION
1) Add a11y labels as per figma description 
2) Focus input when calendar closes (recomended by royce as it allows screenreader to read the selected date in the input) 
3) Add aria-selected for dates/months/years that are selected
4) Add aria-current to dates 
5) Add aria-label indiciating current date month and year 
6) Refactor the way css selectors are added to avoid nested if else statements for better readability 
7) Fix bug where in single mode, user input of valid date does not update the calendar view. 
8) Add disabled styles to td (together with https://github.com/GovTechSG/sgds/pull/483)

Unit tested everything mentioned above, Changes can be preview in dev 

