### PR TITLE
Amplify/configure styles for diff environments [skip-cd]

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,2 @@
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='%STORYBOOK_STYLE_URL%' rel='stylesheet' type='text/css' />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;600;700&display=swap">

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
 import 'bootstrap-icons/font/bootstrap-icons.css';
-// import '@govtechsg/sgds/sgds/sgds.css'
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {
   // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ frontend:
         - rm -rf node_modules && npm ci
     build:
       commands:
-        - npm run build-storybook
+        - if [ "${AWS_BRANCH}" = "v2" ]; npm run prod:build-storybook; else npm run dev:build-storybook; fi
   artifacts:
     baseDirectory: /storybook-static
     files:

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ frontend:
         - rm -rf node_modules && npm ci
     build:
       commands:
-        - if [ "${AWS_BRANCH}" = "v2" ]; npm run prod:build-storybook; else npm run dev:build-storybook; fi
+        - if [ "${AWS_BRANCH}" = "v2" ]; then npm run prod:build-storybook; else npm run dev:build-storybook; fi
   artifacts:
     baseDirectory: /storybook-static
     files:

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "lint": "tsdx lint",
     "size": "size-limit",
     "analyze": "size-limit --why",
-    "storybook": "start-storybook -p 6006 --no-manager-cache",
-    "build-storybook": "build-storybook",
+    "storybook": "STORYBOOK_STYLE_URL=https://v2dev.designsystem.tech.gov.sg/css/sgds.css start-storybook -p 6006 --no-manager-cache",
+    "dev:build-storybook": "STORYBOOK_STYLE_URL=https://v2dev.designsystem.tech.gov.sg/css/sgds.css build-storybook",
+    "prod:build-storybook": "STORYBOOK_STYLE_URL=https://cdn.jsdelivr.net/npm/@govtechsg/sgds/css/sgds.css build-storybook",
     "prepare": "husky install"
   },
   "peerDependencies": {


### PR DESCRIPTION
Differentiates sgds.css for dev and prod environment. 

dev.react storybook  styles points to v2dev.designsystem's sgds.css file to get the latest styling updates for dev environment 

prod react storybook styles points sgds.css published in npm. 