### PR TITLE
fix(pagination): duplicate first page button [skip-cd]

### DIFF
--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -105,7 +105,11 @@ export const Pagination: React.FC<PaginationProps> = ({
   };
 
   const renderFirstPage = () => {
-    const sanitizeStartPage = currentPage - Math.floor(sanitizeLimit / 2);
+    let sanitizeStartPage = currentPage - Math.floor(sanitizeLimit / 2);
+
+    if (pages.length - sanitizeStartPage < limit) {
+      sanitizeStartPage = pages.length + 1 - limit;
+    }
 
     if (sanitizeStartPage > 1) {
       return (


### PR DESCRIPTION
Fix duplicate first page button when `showFirstPage` prop is set and item length is within the limit.