### PR TITLE
Enhancement/clickable tooltip

### DIFF
--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -160,7 +160,7 @@ function wrapRefs(props: any, arrowProps : any) {
 
 const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
   (
-    { children: overlay, transition, popperConfig = {}, ...outerProps },
+    { children: overlay, transition, popperConfig = {}, rootClose = false, ...outerProps },
     outerRef,
   ) => {
     const popperRef = useRef({});
@@ -173,6 +173,7 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
     return (
       <BaseOverlay
         {...outerProps}
+        rootClose={rootClose}
         ref={mergedRef}
         popperConfig={{
           ...popperConfig,

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -4,7 +4,6 @@ import { TooltipPlacement } from '../utils/types';
 import Overlay from '../Overlay/Overlay';
 import OverlayTrigger from '../Overlay/OverlayTrigger';
 import TooltipBox from './TooltipBox';
-import CloseButton from '../CloseButton/CloseButton';
 import PropTypes from 'prop-types';
 import generateId from '../utils/generateId';
 
@@ -53,13 +52,10 @@ export const Tooltip: React.FC<TooltipProps> = ({
         ref: target,
         'aria-describedby': tooltipId,
       })}
-      <Overlay target={target.current} show={show} placement={placement}>
+      <Overlay target={target.current} show={show} placement={placement} rootClose={true} onHide={() => setShow(false)}>
         {(props) => (
           <TooltipBox
             {...props}
-            closeBtn={
-              <CloseButton variant="white" onClick={() => setShow(!show)} />
-            }
             id={tooltipId}
           >
             {content}
@@ -68,7 +64,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
       </Overlay>
     </>
   );
-  // console.log((children as React.ReactElement).props);
   const hoverTooltip = () => (
     <OverlayTrigger
       placement={placement}

--- a/src/Tooltip/TooltipBox.tsx
+++ b/src/Tooltip/TooltipBox.tsx
@@ -10,6 +10,7 @@ export interface TooltipBoxProps
   extends React.HTMLAttributes<HTMLDivElement>,
     BsPrefixProps {
   placement?: Placement;
+  /** @deprecated since 2.8.0 */ 
   arrowProps?: Partial<OverlayArrowProps>;
   show?: boolean;
   popper?: any;
@@ -105,10 +106,8 @@ const TooltipBox = React.forwardRef<HTMLDivElement, TooltipBoxProps>(
         className={classNames(className, bsPrefix, `bs-tooltip-${bsDirection}`)}
         {...props}
       >
-        <div className="tooltip-arrow" {...arrowProps} />
         <div className={`${bsPrefix}-inner`}>
           {children}
-          {closeBtn}
         </div>
       </SGDSWrapper>
     );

--- a/src/Tooltip/TooltipBox.tsx
+++ b/src/Tooltip/TooltipBox.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { OverlayArrowProps } from '@restart/ui/Overlay';
 import { useBootstrapPrefix, useIsRTL, SGDSWrapper } from '../ThemeProvider/ThemeProvider';
 import { Placement } from '../utils/types';
 import { BsPrefixProps, getOverlayDirection } from '../utils/helpers';
@@ -10,8 +9,6 @@ export interface TooltipBoxProps
   extends React.HTMLAttributes<HTMLDivElement>,
     BsPrefixProps {
   placement?: Placement;
-  /** @deprecated since 2.8.0 */ 
-  arrowProps?: Partial<OverlayArrowProps>;
   show?: boolean;
   popper?: any;
   closeBtn?: JSX.Element;
@@ -83,7 +80,6 @@ const TooltipBox = React.forwardRef<HTMLDivElement, TooltipBoxProps>(
       className,
       style,
       children,
-      arrowProps,
       popper: _,
       show: _2,
       closeBtn,

--- a/stories/components/Tooltip/Tooltip.stories.mdx
+++ b/stories/components/Tooltip/Tooltip.stories.mdx
@@ -89,8 +89,8 @@ Wrap the target element or Component with `Tooltip`. `Tooltip` only accepts a si
 
 ## Clickable Tooltip
 
-Set `type` prop to 'click' for a clickable Tooltip. A clickable Tooltip includes `<CloseButton />` which closes the Tooltip onClick.
-The Tooltip can also be closed by clicking on the target element as well. Clickable Tooltip works on any target element or Component like `hover` type
+Set `type` prop to 'click' for a clickable Tooltip.
+The Tooltip can also be closed by clicking on the target element as well or outside of the target element. Clickable Tooltip works on any target element or Component like `hover` type
 
 <Canvas>
   <Story

--- a/tests/Tooltip/Tooltip.test.tsx
+++ b/tests/Tooltip/Tooltip.test.tsx
@@ -54,17 +54,12 @@ describe('Tooltip', () => {
     fireEvent.mouseOver($button as HTMLButtonElement);
     await waitFor(() => {
       expect(screen.queryByText('default tooltip')).toBeNull();
-      expect(screen.queryByText('default tooltip')?.children).toBeUndefined();
     });
 
     // click should open tooltip
     fireEvent.click($button as HTMLButtonElement);
     await waitFor(() => {
       expect(screen.queryByText('default tooltip')).not.toBeNull();
-      expect(screen.queryByText('default tooltip')?.children.length).toEqual(1);
-      expect(
-        screen.queryByText('default tooltip')?.children[0].classList
-      ).toContain('btn-close');
     });
 
     // close tooltip by clicking on target element
@@ -78,17 +73,11 @@ describe('Tooltip', () => {
       expect(screen.queryByText('default tooltip')).not.toBeNull()
     );
 
-    // clicking document cannot close tooltip
+    // clicking can close tooltip
     fireEvent.click(document);
     await waitFor(() =>
-      expect(screen.queryByText('default tooltip')).not.toBeNull()
+      expect(screen.queryByText('default tooltip')).toBeNull()
     );
-    const $closeBtn = screen.queryByText('default tooltip')?.children[0];
-
-    // close tooltip by clicking on closeBtn
-    fireEvent.click($closeBtn as HTMLButtonElement);
-    await waitForElementToBeRemoved(screen.queryByText('default tooltip'));
-    expect(screen.queryByText('default tooltip')).toBeNull();
   });
 
   it('accepts a Component', () => {


### PR DESCRIPTION
#261

includes update of tooltip design (no arrow) 
includes update of tooltip clickable behaviour: click outside target element to close, removed close button

