### PR TITLE
fix(DatePicker): set type of buttons in CalendarHeader to button

### DIFF
--- a/src/DatePicker/CalendarHeader.tsx
+++ b/src/DatePicker/CalendarHeader.tsx
@@ -148,6 +148,7 @@ const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
       }
       const previousButton = (
         <button
+          type="button"
           onClick={handleClickPrevious}
           onKeyDown={handlePressPrevious}
           aria-label={ariaLabels[view]}
@@ -194,6 +195,7 @@ const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
       }
       return (
         <button
+        type="button"
         onClick={handleClickNext}
         onKeyDown={handlePressNext}
         aria-label={ariaLabels[view]}
@@ -221,6 +223,7 @@ const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
 
       return (
         <button
+        type="button"
         onClick={changeView}
         onKeyDown={handlePressChangeView}
         aria-disabled={view === 'year'}

--- a/src/DatePicker/MonthView.tsx
+++ b/src/DatePicker/MonthView.tsx
@@ -237,6 +237,7 @@ export const MonthView = React.forwardRef<HTMLDivElement, MonthViewProps>(
           const currentMonthAriaLabel = `Current month, ${defaultAriaLabel}`;
           return (
             <button
+              type="button"
               aria-label={
                 isCurrentMonthAndYear ? currentMonthAriaLabel : defaultAriaLabel
               }

--- a/src/DatePicker/YearView.tsx
+++ b/src/DatePicker/YearView.tsx
@@ -197,6 +197,7 @@ export const YearView = React.forwardRef<HTMLDivElement, YearViewProps>(
           const isCurrentYear =  CURRENT_YEAR === year
           return (
             <button
+              type="button"
               aria-selected={activeYearClass ? 'true' : 'false'}
               aria-label={isCurrentYear ? `Current year, ${year}` : undefined}
               className={classNames(

--- a/tests/DatePicker/__snapshots__/CalendarHeader.test.tsx.snap
+++ b/tests/DatePicker/__snapshots__/CalendarHeader.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`CalendarHeader should have default html structure 1`] = `
   >
     <button
       aria-label="Show previous month"
+      type="button"
     >
       <i
         class="bi bi-chevron-left"
@@ -16,11 +17,13 @@ exports[`CalendarHeader should have default html structure 1`] = `
       aria-disabled="false"
       aria-label=""
       aria-live="polite"
+      type="button"
     >
       March 2022
     </button>
     <button
       aria-label="Show next month"
+      type="button"
     >
       <i
         class="bi bi-chevron-right"


### PR DESCRIPTION
**The problem:**
Some of the buttons inside a Datepicker component are not typed. Chrome will default the button type to "submit" which will cause the parent form to be submitted.

https://github.com/user-attachments/assets/fad305a1-60f0-4a4c-87b1-31968ca1a699

Sample Code:

```tsx
import { useState } from "react";
import {
  Button,
  Form,
  DatePicker,
  RangeSelectionValue,
} from "@govtechsg/sgds-react";
import dayjs from "dayjs";

function TestForm({
  searchParams,
}: {
  searchParams: { startTime: string; endTime: string };
}) {
  const [startTime, setStartTime] = useState<string | undefined>(
    searchParams.startTime
  );
  const [endTime, setEndTime] = useState<string | undefined>(
    searchParams.endTime
  );

  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
    event.preventDefault();
    console.log("Form submitted");
  };
  const handleDateRangeChange = (
    dateRange: RangeSelectionValue | undefined
  ) => {
    console.log({ dateRange });
    setStartTime(dateRange?.start && dayjs(dateRange.start).toISOString());
    setEndTime(dateRange?.end && dayjs(dateRange.end).toISOString());
  };

  return (
    <>
      <Form onSubmit={handleSearch}>
        <Form.Group className="mb-3">
          <Form.Label>Start Date & Time</Form.Label>
          <DatePicker
            initialValue={{
              start: dayjs(startTime).toDate(),
              end: dayjs(endTime).toDate(),
            }}
            displayDate={dayjs(startTime).toDate()}
            mode="range"
            maxDate={dayjs().toISOString()}
            onChangeDate={(date) =>
              handleDateRangeChange(date as RangeSelectionValue)
            }
          />
        </Form.Group>

        <Button variant="primary" type="submit" size="sm">
          Generate Chart
        </Button>
      </Form>
    </>
  );
}

export default TestForm;


```